### PR TITLE
New Firmware Update Testcases

### DIFF
--- a/ctam/interfaces/comptool_dut.py
+++ b/ctam/interfaces/comptool_dut.py
@@ -131,7 +131,7 @@ class CompToolDut(Dut):
                     "URI": uri,
             }
             if mode == "POST":
-                msg.update({"Method":"POST","Data":"{}".format(body),})
+                msg.update({"Method":"POST","Data":"{}".format(body),}) # FIXME: It floods the logs. Do we need to log the entire body? 
                 response = self.redfish_ifc.post(path=uri, body=body, headers=headers)
             elif mode == "PATCH":
                 msg.update({"Mode":"PATCH","Data":"{}".format(body),})

--- a/ctam/interfaces/comptool_dut.py
+++ b/ctam/interfaces/comptool_dut.py
@@ -75,6 +75,10 @@ class CompToolDut(Dut):
             self.connection_ip_address
         )
         
+        if not self.check_ping_status(self.connection_ip_address): # FIXME: Use logging method
+            print("[FATAL] Unable to ping the ip address. Please check the IP is valid or not.")
+            sys.exit(1)
+        
         # Set up SSH Tunneling if requested
         self.BindedPort = None
         if config["properties"].get("SshTunnel"):
@@ -93,9 +97,7 @@ class CompToolDut(Dut):
 
         # TODO investigate storing FW update files via add_software_info() in super
         connection_url = ("http://" if self.SshTunnel else "https://") + self.connection_ip_address + "/"
-        if not self.check_ping_status(self.connection_ip_address): # FIXME: Use logging method
-            print("[FATAL] Unable to ping the ip address. Please check the IP is valid or not.")
-            sys.exit(1)
+        
         self.redfish_ifc = redfish.redfish_client(
             connection_url,
             username=self.__user_name,
@@ -189,7 +191,7 @@ class CompToolDut(Dut):
                 self.BindedPort = port
                 break
         if self.BindedPort is None:
-            raise Exception("Failed to bind port! Please make sure the host machine has port forwarding enabled and there is at least one port avaailable in {PortList}.")
+            raise Exception(f"Failed to bind port! Please make sure the host machine has port forwarding enabled and there is at least one port avaailable in {PortList}.")
         print(f"Binded port {self.BindedPort}") # FIXME: Use logging method
         return
     
@@ -242,24 +244,24 @@ class CompToolDut(Dut):
             system_details = self.run_redfish_command(system_detail_uri).dict
             bmc_fw_inv = self.run_redfish_command(bmc_fw_inv_uri).dict
             if system_details and ("error" not in system_details):
-                t.add_row(["Model", system_details["Model"]])
-                t.add_row(["Manufacturer", system_details["Manufacturer"]])
-                t.add_row(["HostName", system_details["HostName"]])
-                t.add_row(["System UUID", system_details["UUID"]])
-                t.add_row(["Bios Version", system_details["BiosVersion"]])
-                t.add_row(["PartNumber", system_details["PartNumber"]])
-                t.add_row(["SerialNumber", system_details["SerialNumber"]])
-                t.add_row(["Processor Model", system_details["ProcessorSummary"]["Model"]])
+                t.add_row(["Model", system_details.get("Model")])
+                t.add_row(["Manufacturer", system_details.get("Manufacturer")])
+                t.add_row(["HostName", system_details.get("HostName")])
+                t.add_row(["System UUID", system_details.get("UUID")])
+                t.add_row(["Bios Version", system_details.get("BiosVersion")])
+                t.add_row(["PartNumber", system_details.get("PartNumber")])
+                t.add_row(["SerialNumber", system_details.get("SerialNumber")])
+                t.add_row(["Processor Model", system_details.get("ProcessorSummary").get("Model")])
                 t.add_row(
                     [
                         "Processor Health",
-                        system_details["ProcessorSummary"]["Status"]["Health"],
+                        system_details.get("ProcessorSummary").get("Status").get("Health"),
                     ]
                 )
                 t.add_row(
                     [
                         "Processor State",
-                        system_details["ProcessorSummary"]["Status"]["State"],
+                        system_details.get("ProcessorSummary").get("Status").get("State"),
                     ]
                 )
             else:

--- a/ctam/interfaces/functional_ifc.py
+++ b/ctam/interfaces/functional_ifc.py
@@ -124,18 +124,32 @@ class FunctionalIfc:
                 self.dut().package_config.get("GPU_FW_IMAGE", {}).get("Package", ""),
             )
             json_fw_file_payload = PLDMFwpkg.corrupt_package_UUID(golden_fwpkg_path)
+        
         elif image_type == "empty_metadata":
             if corrupted_component_id is None:
                 corrupted_component_id = self.ctam_get_component_to_be_corrupted()
-            msg = f"Corrputed component ID: {corrupted_component_id}"
+            msg = f"Corrupted component ID: {corrupted_component_id}"
             self.test_run().add_log(LogSeverity.DEBUG, msg)
             golden_fwpkg_path = os.path.join(
                 self.dut().cwd,
                 self.dut().package_config.get("GPU_FW_IMAGE", {}).get("Path", ""),
                 self.dut().package_config.get("GPU_FW_IMAGE", {}).get("Package", ""),
             )
-            metadata_size = self.dut().package_config.get("GPU_FW_IMAGE_EMPTY_METADATA", {}).get("MetadataSizeBytes", 1024)
+            metadata_size = self.dut().package_config.get("GPU_FW_IMAGE_CORRUPT_COMPONENT", {}).get("MetadataSizeBytes", 4096)
             json_fw_file_payload = PLDMFwpkg.clear_component_metadata_in_pkg(golden_fwpkg_path, corrupted_component_id, metadata_size)
+        
+        elif image_type == "empty_component":
+            if corrupted_component_id is None:
+                corrupted_component_id = self.ctam_get_component_to_be_corrupted()
+            msg = f"Corrupted component ID: {corrupted_component_id}"
+            self.test_run().add_log(LogSeverity.DEBUG, msg)
+            golden_fwpkg_path = os.path.join(
+                self.dut().cwd,
+                self.dut().package_config.get("GPU_FW_IMAGE", {}).get("Path", ""),
+                self.dut().package_config.get("GPU_FW_IMAGE", {}).get("Package", ""),
+            )
+            json_fw_file_payload = PLDMFwpkg.clear_component_image_in_pkg(golden_fwpkg_path, corrupted_component_id)
+        
         elif image_type == "backup":
             json_fw_file_payload = os.path.join(
                 self.dut().cwd,
@@ -191,7 +205,7 @@ class FunctionalIfc:
         :rtype:                 string
         """
         pldm_json_file = ""
-        if image_type == "default":
+        if image_type == "default" or image_type == "corrupt_component":
             pldm_json_file = os.path.join(
                 self.dut().cwd,
                 self.dut().package_config.get("GPU_FW_IMAGE", {}).get("Path", ""),

--- a/ctam/interfaces/functional_ifc.py
+++ b/ctam/interfaces/functional_ifc.py
@@ -1,5 +1,6 @@
 """
 Copyright (c) Microsoft Corporation
+Copyright (c) NVIDIA CORPORATION
 
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -9,13 +10,14 @@ import os
 import json
 import subprocess
 import time
+from datetime import datetime
 from typing import Optional, List
 
 import ocptv.output as tv
 from ocptv.output import LogSeverity
 
 from interfaces.comptool_dut import CompToolDut
-
+from utils.fwpkg_utils import FwpkgSignature, PLDMFwpkg
 
 class FunctionalIfc:
     """
@@ -72,7 +74,7 @@ class FunctionalIfc:
         """
         pass
 
-    def get_JSONFWFilePayload_file(self, image_type="default"):
+    def get_JSONFWFilePayload_file(self, image_type="default", corrupted_component_id=None):
         """
         :Description:           Get Payload file
 
@@ -97,15 +99,43 @@ class FunctionalIfc:
                 .get("Package", ""),
             )
         elif image_type == "invalid_sign":
-            json_fw_file_payload = os.path.join(
+            if self.dut().package_config.get("GPU_FW_IMAGE_INVALID_SIGNED", {}).get("Package", "") != "":
+                json_fw_file_payload = os.path.join(
+                    self.dut().cwd,
+                    self.dut()
+                    .package_config.get("GPU_FW_IMAGE_INVALID_SIGNED", {})
+                    .get("Path", ""),
+                    self.dut()
+                    .package_config.get("GPU_FW_IMAGE_INVALID_SIGNED", {})
+                    .get("Package", ""),
+                )
+            else:
+                golden_fwpkg_path = os.path.join(
+                    self.dut().cwd,
+                    self.dut().package_config.get("GPU_FW_IMAGE", {}).get("Path", ""),
+                    self.dut().package_config.get("GPU_FW_IMAGE", {}).get("Package", ""),
+                )
+                json_fw_file_payload = FwpkgSignature.clear_signature_in_pkg(golden_fwpkg_path)
+            
+        elif image_type == "invalid_uuid":
+            golden_fwpkg_path = os.path.join(
                 self.dut().cwd,
-                self.dut()
-                .package_config.get("GPU_FW_IMAGE_INVALID_SIGNED", {})
-                .get("Path", ""),
-                self.dut()
-                .package_config.get("GPU_FW_IMAGE_INVALID_SIGNED", {})
-                .get("Package", ""),
+                self.dut().package_config.get("GPU_FW_IMAGE", {}).get("Path", ""),
+                self.dut().package_config.get("GPU_FW_IMAGE", {}).get("Package", ""),
             )
+            json_fw_file_payload = PLDMFwpkg.corrupt_package_UUID(golden_fwpkg_path)
+        elif image_type == "empty_metadata":
+            if corrupted_component_id is None:
+                corrupted_component_id = self.ctam_get_component_to_be_corrupted()
+            msg = f"Corrputed component ID: {corrupted_component_id}"
+            self.test_run().add_log(LogSeverity.DEBUG, msg)
+            golden_fwpkg_path = os.path.join(
+                self.dut().cwd,
+                self.dut().package_config.get("GPU_FW_IMAGE", {}).get("Path", ""),
+                self.dut().package_config.get("GPU_FW_IMAGE", {}).get("Package", ""),
+            )
+            metadata_size = self.dut().package_config.get("GPU_FW_IMAGE_EMPTY_METADATA", {}).get("MetadataSizeBytes", 1024)
+            json_fw_file_payload = PLDMFwpkg.clear_component_metadata_in_pkg(golden_fwpkg_path, corrupted_component_id, metadata_size)
         elif image_type == "backup":
             json_fw_file_payload = os.path.join(
                 self.dut().cwd,
@@ -358,26 +388,140 @@ class FunctionalIfc:
         self.test_run().add_log(LogSeverity.INFO, msg)
         return JSONData
     
-    def ctam_activate_ac(self):
+    def ctam_activate_ac(self, check_time=False):
         """
         :Description:					Activate AC
+        
+        :param check_time:              Check the activation time does not exceed maximum time per spec
 
         :returns:				    	ActivationStatus
         :rtype: 						Bool
         """
         MyName = __name__ + "." + self.ctam_activate_ac.__qualname__
         ActivationStatus = False
+        
+        FwActivationTimeMax = self.dut().dut_config["FwActivationTimeMax"]["value"]
+        if check_time and self.dut().dut_config["PowerOnWaitTime"]["value"] > FwActivationTimeMax:
+            msg = f"PowerOnWaitTime is greater than FwActivationTimeMax as per the json config file. Setting FwActivationTimeMax = PowerOnWaitTime"
+            self.test_run().add_log(LogSeverity.WARNING, msg)
+            FwActivationTimeMax = self.dut().dut_config["PowerOnWaitTime"]["value"]
+        
         self.NodeACReset()  # NodeACReset declaration pending
-
+        
+        ActivationStartTime = time.time() - self.dut().dut_config["PowerOnWaitTime"]["value"] # When the system was reset
         while "error" in self.IsGPUReachable():  # declaration pending
             msg = "GPU showing error"
             self.test_run().add_log(LogSeverity.DEBUG, msg)
         while (self.IsGPUReachable())["Status"][
             "State"
-        ] != "Enabled":  # declaration pending
+        ] != "Enabled" \
+                and (not check_time or (check_time and (time.time() - ActivationStartTime) <= FwActivationTimeMax)): # declaration pending
             msg = "Waiting for GPU to be back up, {}".format(
                 (self.IsGPUReachable())["Status"]["State"]
             )
             self.test_run().add_log(LogSeverity.DEBUG, msg)
-        ActivationStatus = True
+            time.sleep(30)
+        ActivationEndTime = time.time()
+        
+        if check_time and (ActivationEndTime - ActivationStartTime) > FwActivationTimeMax:
+            ActivationStatus = False
+            msg = f"Activation is taking longer than the maximum time specified {FwActivationTimeMax} seconds."
+            self.test_run().add_log(LogSeverity.WARNING, msg)
+        else:
+            ActivationStatus = True
+        
         return ActivationStatus
+    
+    def RedfishTriggerDumpCollection(self, DiagnosticDataType, URI, OEMDiagnosticDataType=None):
+        """
+        :Description:                     It will trigger the collection of diagnostic data.
+        :param DiagnosticDataType:		  e.g. Manager, OEM etc.
+        :param URI:		                  URI for creating URL
+        :param OEMDiagnosticDataType:     Type of OEM Diagnostic. default=None.
+
+        :returns:		      JSON data after executing redfish command
+        :rtype:               JSON Dict
+        """
+        MyName = __name__ + "." + self.RedfishTriggerDumpCollection.__qualname__
+        URL = URI + "/LogServices/Dump/Actions/LogService.CollectDiagnosticData"
+        msg = "Dump Collection URL = {}".format(URL)
+        self.test_run().add_log(LogSeverity.DEBUG, msg)
+        
+        payload = { "DiagnosticDataType": DiagnosticDataType }
+        if OEMDiagnosticDataType:
+            payload["OEMDiagnosticDataType"] = "DiagnosticType=" + OEMDiagnosticDataType
+        response = self.dut().redfish_ifc.post(path=URL, body=payload)
+        JSONData = response.dict
+
+        msg = "{0}: RedFish Input: {1} Result: {2}".format(MyName, payload, JSONData)
+        self.test_run().add_log(LogSeverity.INFO, msg)
+        
+        return JSONData
+    
+    def RedfishDownloadDump(self, DumpURI):
+        """
+        :Description:              It will download the specified dump using redfish command and untar the downloaded dump.
+        :param DumpLocation:	   Dump location URI 
+
+        :returns:				   DumpPath (Path to downloaded dump)
+        :rtype:                    string
+        """
+        MyName = __name__ + "." + self.RedfishDownloadDump.__qualname__
+        URL = DumpURI + "/attachment"
+        msg = "Dump Entry URL = {}".format(URL)
+        self.test_run().add_log(LogSeverity.DEBUG, msg)
+        
+        dt = datetime.now().strftime("%m_%d_%Y_%H_%M_%S")
+        dump_tarball_path = os.path.join(
+                self.dut().cwd, 
+                "workspace",
+                "{}_dump.tar.xz".format(dt))
+        response =  self.dut().redfish_ifc.get(path=URL)
+        try:
+            with open(dump_tarball_path, 'wb') as fd:
+                fd.write(response.read)
+            # Unzip the .tar file
+            import tarfile
+            dump = tarfile.open(dump_tarball_path)
+            DumpPath = os.path.join(
+                self.dut().cwd, 
+                "workspace", 
+                "{}_dump".format(dt))
+            dump.extractall(DumpPath) # This will create a directory if it's not present already.
+            dump.close()
+            os.remove(dump_tarball_path) # Delete the tarball as it's not needed anymore
+            return DumpPath
+        except Exception as e:
+            print(str(e))
+            return None
+    
+    def ctam_monitor_task(self, TaskID):
+        """
+        :Description:       CTAM Monitor a Task
+        :returns:	        (Task_Completed, JSONData response)
+        :rtype:             Tuple
+        """
+        Task_Completed = False
+        TaskURI = self.dut().uri_builder.format_uri(
+            redfish_str="{BaseURI}/TaskService/Tasks/" + "{}".format(TaskID), component_type="GPU"
+        )
+        if self.dut().is_debug_mode():
+            self.test_run().add_log(LogSeverity.DEBUG, f"Task URI: {TaskURI}")
+            
+        response = self.dut().redfish_ifc.get(TaskURI)
+        JSONData = response.dict
+        while JSONData["TaskState"] == "Running":
+            response = self.dut().redfish_ifc.get(TaskURI)
+            JSONData = response.dict
+            if self.dut().is_debug_mode():
+                self.test_run().add_log(LogSeverity.DEBUG,
+                    "Task Percentage_Completion = {}".format(JSONData["PercentComplete"])
+                )
+            time.sleep(30)
+        if JSONData["TaskState"] == "Completed":
+            Task_Completed = True
+        else:
+            Task_Completed = False
+        
+        return Task_Completed, JSONData
+

--- a/ctam/interfaces/health_check_ifc.py
+++ b/ctam/interfaces/health_check_ifc.py
@@ -1,10 +1,14 @@
 """
 Copyright (c) Microsoft Corporation
+Copyright (c) NVIDIA CORPORATION
 
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 
 """
+import time
+import json
+import os
 from typing import Optional, List
 from interfaces.functional_ifc import FunctionalIfc
 
@@ -136,3 +140,107 @@ class HealthCheckIfc(FunctionalIfc):
             #     "{}{}".format(self.dut_obj.gpu_redfish_data["GPUMC"], clear_dump_uri)
             # )
         return result
+    
+    def trigger_self_test_dump_collection(self):
+        """
+        :Description:							Trigger Self-test Dump Collection
+
+        :returns:				    			SelfTestDump_Status
+        :rtype: 								Bool
+        """
+        MyName = __name__ + "." + self.trigger_self_test_dump_collection.__qualname__
+        StartTime = time.time()
+
+        selftest_dump_collection_uri = self.dut().uri_builder.format_uri(
+            redfish_str="{BaseURI}{SystemURI}", component_type="BMC"
+        )
+        JSONData = self.RedfishTriggerDumpCollection(
+            "OEM",
+            selftest_dump_collection_uri,
+            "SelfTest"
+        )
+        if self.dut().is_debug_mode():
+            self.test_run().add_log(LogSeverity.DEBUG, f"{MyName}  {JSONData}")
+            
+        # Now Wait for TaskService/Tasks/$ID TaskState to reflect completed.
+        if "error" not in JSONData:
+            TaskID = JSONData["Id"]
+            
+            if self.dut().is_debug_mode():
+                self.test_run().add_log(LogSeverity.DEBUG, f"Self-test Dump Collection Task ID = {TaskID}")
+            DeployTime = time.time()
+            Task_Completed, JSONData = self.ctam_monitor_task(TaskID)
+            EndTime = time.time()
+            if Task_Completed:
+                for http_header in JSONData['Payload']['HttpHeaders']:
+                    if 'Location' in  http_header:
+                        self.selftest_dump_entry_uri=http_header.split(': ')[1]
+                        if self.dut().is_debug_mode():
+                            self.test_run().add_log(LogSeverity.DEBUG, 
+                                "Self-test Dump Location = {}".format(self.selftest_dump_entry_uri)
+                            )
+                if self.selftest_dump_entry_uri:
+                    SelfTestDump_Status = True
+                else:
+                    SelfTestDump_Status = False
+            else:
+                SelfTestDump_Status = False
+            msg= "{0}: Self-test Dump Trigger Time: {1} Self-test Dump Collection Time: {2} \n Redfish Outcome: {3}".format(
+                MyName,
+                DeployTime - StartTime,
+                EndTime - StartTime,
+                json.dumps(JSONData, indent=4),
+            )
+            self.test_run().add_log(LogSeverity.DEBUG, msg)
+            
+        else:
+            SelfTestDump_Status = False
+        
+        return SelfTestDump_Status
+    
+    def download_self_test_dump(self):
+        """
+        :Description:							Download Self-test Dump
+
+        :returns:				    			SelfTestDump_Status
+        :rtype: 								Bool
+        """
+        MyName = __name__ + "." + self.download_self_test_dump.__qualname__
+        
+        if self.selftest_dump_entry_uri:
+            self.selftest_dump_path  = self.RedfishDownloadDump(self.selftest_dump_entry_uri)
+            msg = "Self test Dump location: {}".format(self.selftest_dump_path)
+            self.test_run().add_log(LogSeverity.DEBUG, msg)
+            self.selftest_dump_entry_uri = None
+            
+        if self.selftest_dump_path:
+            SelfTestDump_Status = True
+        else:
+            SelfTestDump_Status = False
+        
+        return SelfTestDump_Status
+
+    
+    def check_self_test_report(self):
+        """
+        :Description:							Check Self-test Report for any Failure
+
+        :returns:				    			SelfTestReport_Status
+        :rtype: 								Bool
+        """
+        MyName = __name__ + "." + self.download_self_test_dump.__qualname__
+        SelfTestReport_Status = False
+        
+        for root, dirs, files in os.walk(self.selftest_dump_path):
+            if "selftest_report.json" in files:
+                with open(os.path.join(root, "selftest_report.json"), 'r') as fd:
+                    SelfTestReport_JSON = json.load(fd)
+                if SelfTestReport_JSON["header"]["summary"]["test-case-failed"] == 0:
+                    SelfTestReport_Status = True
+                else:
+                    msg = "Self-test reported failure with test-case-failed = {}"\
+                        .format(SelfTestReport_JSON["header"]["summary"]["test-case-failed"])
+                    self.test_run().add_log(LogSeverity.ERROR, msg)
+
+        return SelfTestReport_Status
+

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_activation_time.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_activation_time.py
@@ -1,19 +1,19 @@
 """
-Copyright (c) Microsoft Corporation
 Copyright (c) NVIDIA CORPORATION
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 
-:Test Name:		CTAM Test Full Device Update In Loop
-:Test ID:		F8
+:Test Name:		CTAM Test Full Device Update Activation Time
+:Test ID:		F64
 :Group Name:	fw_update
 :Score Weight:	10
 
-:Description:	Test case of full firmware update in a loop. To verify the ongoing rollback is not affected by 
-:Usage 1:		python ctam.py -w ..\workspace -t F8
-:Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Full Device Update In Loop"
+:Description:	Verify that firmware activation operation does not exceed the max time specified in the requirements.
+:Usage 1:		python ctam.py -w ..\workspace -t F64
+:Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Full Device Update Activation Time"
 
 """
+
 from typing import Optional, List
 from tests.test_case import TestCase
 from ocptv.output import (
@@ -28,16 +28,16 @@ from tests.fw_update.fw_update_group_N._fw_update_group_N import (
 )
 
 
-class CTAMTestFullDeviceUpdateInLoop(TestCase):
+class CTAMTestFullDeviceUpdateActivationTime(TestCase):
     """
-    Verify values of Software Inventory Collection are present
+    Verify that firmware activation operation does not exceed the max time specified in the requirements
 
     :param TestCase: super class for all test cases
     :type TestCase:
     """
 
-    test_name: str = "CTAM Test Full Device Update In Loop"
-    test_id: str = "F8"
+    test_name: str = "CTAM Test Full Device Update Activation Time"
+    test_id: str = "F64"
     score_weight: int = 10
     tags: List[str] = []
 
@@ -68,10 +68,8 @@ class CTAMTestFullDeviceUpdateInLoop(TestCase):
 
         step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
         with step1.scope():
-            if not self.group.fw_update_ifc.ctam_fw_update_precheck(
-                image_type="backup"
-            ):
-                step1.add_log(LogSeverity.INFO, f"[{self.test_id}] : FW Update Capable")
+            if not self.group.fw_update_ifc.ctam_fw_update_precheck():
+                step1.add_log(LogSeverity.INFO, f"{self.test_id} : FW Update Capable")
             else:
                 step1.add_log(
                     LogSeverity.INFO, f"{self.test_id} : FW Update Not Required"
@@ -79,9 +77,7 @@ class CTAMTestFullDeviceUpdateInLoop(TestCase):
 
         step2 = self.test_run().add_step(f"{self.__class__.__name__} run(), step2")  # type: ignore
         with step2.scope():
-            if self.group.fw_update_ifc.ctam_stage_fw(
-                wait_for_stage_completion=False
-            ):
+            if self.group.fw_update_ifc.ctam_stage_fw():
                 step2.add_log(LogSeverity.INFO, f"{self.test_id} : FW Update Staged")
             else:
                 step2.add_log(
@@ -89,57 +85,31 @@ class CTAMTestFullDeviceUpdateInLoop(TestCase):
                 )
                 result = False
 
-        step3 = self.test_run().add_step(f"{self.__class__.__name__} run(), step3")  # type: ignore
-        with step3.scope():
-            keep_disturbing = True
-            disturb_count = 1
-            while keep_disturbing:
-                if self.group.fw_update_ifc.ctam_stage_fw(image_type="backup"):
-                    keep_disturbing = False
-                    step3.add_log(
-                        LogSeverity.INFO,
-                        f"{self.test_id} : FW Update restarted, Disturb Count = {disturb_count}",
-                    )
-                else:
-                    step3.add_log(
-                        LogSeverity.ERROR,
-                        f"{self.test_id} : FW Update Disturb Failed as expected",
-                    )
-                    disturb_count = disturb_count + 1
-
-            if disturb_count == 1:
-                result = False
-                step3.add_log(
-                    LogSeverity.ERROR,
-                    f"{self.test_id} : FW Update Disturb was successful in first shot - Not Expected",
-                )
-
         if result:
-            step4 = self.test_run().add_step(f"{self.__class__.__name__} run(), step4")  # type: ignore
-            with step4.scope():
-                if self.group.fw_update_ifc.ctam_activate_ac():
-                    step4.add_log(
+            step3 = self.test_run().add_step(f"{self.__class__.__name__} run(), step3")  # type: ignore
+            with step3.scope():
+                if self.group.fw_update_ifc.ctam_activate_ac(check_time=True):
+                    step3.add_log(
                         LogSeverity.INFO, f"{self.test_id} : FW Update Activate"
                     )
                 else:
-                    step4.add_log(
+                    step3.add_log(
                         LogSeverity.ERROR,
                         f"{self.test_id} : FW Update Activation Failed",
                     )
                     result = False
-
+                    
         if result:
-            step5 = self.test_run().add_step(f"{self.__class__.__name__} run(), step5")
-            with step5.scope():
-                if self.group.fw_update_ifc.ctam_fw_update_verify(image_type="backup"):
-                    step5.add_log(
+            step4 = self.test_run().add_step(f"{self.__class__.__name__} run(), step4")
+            with step4.scope():
+                if self.group.fw_update_ifc.ctam_fw_update_verify():
+                    step4.add_log(
                         LogSeverity.INFO,
                         f"{self.test_id} : Update Verification Completed",
                     )
                 else:
-                    step5.add_log(
-                        LogSeverity.ERROR,
-                        f"{self.test_id} : Update Verification Failed",
+                    step4.add_log(
+                        LogSeverity.INFO, f"{self.test_id} : Update Verification Failed"
                     )
                     result = False
 

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_staging_interruption_with_single_device_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_staging_interruption_with_single_device_update.py
@@ -1,0 +1,190 @@
+"""
+Copyright (c) NVIDIA CORPORATION
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+
+:Test Name:		CTAM Test Full Device Update Staging Interruption With Single Device Update
+:Test ID:		F24
+:Group Name:	fw_update
+:Score Weight:	10
+
+:Description:	Test case of full firmware update in a loop. To verify the ongoing rollback is not affected by 
+:Usage 1:		python ctam.py -w ..\workspace -t F24
+:Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Full Device Update Staging Interruption With Single Device Update"
+
+"""
+from typing import Optional, List
+from tests.test_case import TestCase
+from ocptv.output import (
+    DiagnosisType,
+    LogSeverity,
+    SoftwareType,
+    TestResult,
+    TestStatus,
+)
+from tests.fw_update.fw_update_group_N._fw_update_group_N import (
+    FWUpdateTestGroupN,
+)
+
+
+class CTAMTestFullDeviceUpdateInterruptionWithSingleDeviceUpdate(TestCase):
+    """
+    Verify single device fails whhen a full device fw update staging is in progress
+
+    :param TestCase: super class for all test cases
+    :type TestCase:
+    """
+
+    test_name: str = "CTAM Test Full Device Update Staging Interruption With Single Device Update"
+    test_id: str = "F24"
+    score_weight: int = 10
+    tags: List[str] = []
+
+    def __init__(self, group: FWUpdateTestGroupN):
+        """
+        _summary_
+        """
+        super().__init__()
+        self.group = group
+
+    def setup(self):
+        """
+        set environment state for this test only
+        """
+        # call super first
+        super().setup()
+
+        # add custom setup here
+        step1 = self.test_run().add_step(f"{self.__class__.__name__}  setup()...")
+        with step1.scope():
+            pass
+
+    def run(self) -> TestResult:
+        """
+        actual test verification
+        """
+        result = True
+        fwupd_task_id = None
+
+        step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
+        with step1.scope():
+            if not self.group.fw_update_ifc.ctam_fw_update_precheck(image_type="backup"):
+                step1.add_log(LogSeverity.INFO, f"[{self.test_id}] : FW Update Capable")
+            else:
+                step1.add_log(
+                    LogSeverity.INFO, f"{self.test_id} : FW Update Not Required"
+                )
+
+        step2 = self.test_run().add_step(f"{self.__class__.__name__} run(), step2")  # type: ignore
+        with step2.scope():
+            fwupd_status, fwupd_task_id = self.group.fw_update_ifc.ctam_stage_fw(image_type="backup", 
+                                                                                 wait_for_stage_completion=False,
+                                                                                 return_task_id=True)
+            if fwupd_status:
+                step2.add_log(LogSeverity.INFO, f"{self.test_id} : FW Update Staged")
+            else:
+                step2.add_log(
+                    LogSeverity.ERROR, f"{self.test_id} : FW Update Stage Failed"
+                )
+                result = False
+
+        if result:
+            step3 = self.test_run().add_step(f"{self.__class__.__name__} run(), step3")  # type: ignore
+            with step3.scope():
+                if component_list := self.group.fw_update_ifc.ctam_build_updatable_device_list():
+                    device = component_list[0]
+                    step1_device = self.test_run().add_step(f"{self.__class__.__name__} run(), step1_{device}")  # type: ignore
+                    with step1_device.scope():
+                        if self.group.fw_update_ifc.ctam_selectpartiallist(count=1, specific_targets=[device]):
+                            step1_device.add_log(LogSeverity.INFO, f"{self.test_id} : Single Device Selected")
+                        else:
+                            step1_device.add_log(LogSeverity.ERROR, f"{self.test_id} : Single Device Selection Failed")
+                            result = False
+
+                    if result:
+                        step2_device = self.test_run().add_step(f"{self.__class__.__name__} run(), step2_{device}")  # type: ignore
+                        with step2_device.scope():
+                            if self.group.fw_update_ifc.ctam_stage_fw(partial=1):
+                                step2_device.add_log(LogSeverity.INFO, f"{self.test_id} : FW Update Staged - Unexpected")
+                                result = False
+                            else:
+                                step2_device.add_log(
+                                    LogSeverity.ERROR, f"{self.test_id} : FW Update Stage Failed as expected"
+                                )
+                else:
+                    step3.add_log(LogSeverity.INFO, f"{self.test_id} : No updatable devices, exiting")
+                    result = False
+
+        if result:
+            step4 = self.test_run().add_step(f"{self.__class__.__name__} run(), step4")  # type: ignore
+            with step4.scope():
+                if fwupd_task_id is not None:
+                    TaskCompleted, _ =  self.group.fw_update_ifc.ctam_monitor_task(fwupd_task_id)
+                    if TaskCompleted: 
+                        step4.add_log(
+                            LogSeverity.INFO, f"{self.test_id} : FW Update Staging Verification"
+                        )
+                    else:
+                        step4.add_log(
+                            LogSeverity.ERROR, f"{self.test_id} : FW Update Staging Verification - Task Failed"
+                        )
+                        result = False
+                else:
+                    step4.add_log(
+                        LogSeverity.ERROR,
+                        f"{self.test_id} : FW Update Staging Verification - No task ID",
+                    )
+                    result = False
+                    
+        if result:
+            step5 = self.test_run().add_step(f"{self.__class__.__name__} run(), step5")  # type: ignore
+            with step5.scope():
+                if self.group.fw_update_ifc.ctam_activate_ac():
+                    step5.add_log(
+                        LogSeverity.INFO, f"{self.test_id} : FW Update Activate"
+                    )
+                else:
+                    step5.add_log(
+                        LogSeverity.ERROR,
+                        f"{self.test_id} : FW Update Activation Failed",
+                    )
+                    result = False
+
+        if result:
+            step6 = self.test_run().add_step(f"{self.__class__.__name__} run(), step6")
+            with step6.scope():
+                if self.group.fw_update_ifc.ctam_fw_update_verify(image_type="backup"):
+                    step5.add_log(
+                        LogSeverity.INFO,
+                        f"{self.test_id} : Update Verification Completed",
+                    )
+                else:
+                    step6.add_log(
+                        LogSeverity.ERROR,
+                        f"{self.test_id} : Update Verification Failed",
+                    )
+                    result = False
+
+        # ensure setting of self.result and self.score prior to calling super().run()
+        self.result = TestResult.PASS if result else TestResult.FAIL
+        if self.result == TestResult.PASS:
+            self.score = self.score_weight
+
+        # call super last to log result and score
+        super().run()
+        return self.result
+
+    def teardown(self):
+        """
+        undo environment state change from setup() above, this function is called even if run() fails or raises exception
+        """
+        # add custom teardown here
+        step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
+        with step1.scope():
+            if self.group.fw_update_ifc.ctam_pushtargets():
+                step1.add_log(LogSeverity.INFO, f"{self.test_id} : Push URI Targets Reset")
+            else:
+                step1.add_log(LogSeverity.WARNING, f"{self.test_id} : Push URI Targets Reset - Failed")
+
+        # call super teardown last
+        super().teardown()

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_staging_time.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_staging_time.py
@@ -1,0 +1,129 @@
+"""
+Copyright (c) NVIDIA CORPORATION
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+
+:Test Name:		CTAM Test Full Device Update Staging Time
+:Test ID:		F63
+:Group Name:	fw_update
+:Score Weight:	10
+
+:Description:	Verfy that firmware copy operation (staging) does not exceed the max time specified in the requirements.
+:Usage 1:		python ctam.py -w ..\workspace -t F63
+:Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Full Device Update Staging Time"
+
+"""
+
+from typing import Optional, List
+from tests.test_case import TestCase
+from ocptv.output import (
+    DiagnosisType,
+    LogSeverity,
+    SoftwareType,
+    TestResult,
+    TestStatus,
+)
+from tests.fw_update.fw_update_group_N._fw_update_group_N import (
+    FWUpdateTestGroupN,
+)
+
+
+class CTAMTestFullDeviceUpdateStagingTime(TestCase):
+    """
+    Verfy that firmware copy operation (staging) does not exceed the max time specified in the requirements
+
+    :param TestCase: super class for all test cases
+    :type TestCase:
+    """
+
+    test_name: str = "CTAM Test Full Device Update Staging Time"
+    test_id: str = "F63"
+    score_weight: int = 10
+    tags: List[str] = []
+
+    def __init__(self, group: FWUpdateTestGroupN):
+        """
+        _summary_
+        """
+        super().__init__()
+        self.group = group
+
+    def setup(self):
+        """
+        set environment state for this test only
+        """
+        # call super first
+        super().setup()
+
+        # add custom setup here
+        step1 = self.test_run().add_step(f"{self.__class__.__name__}  setup()...")
+        with step1.scope():
+            pass
+
+    def run(self) -> TestResult:
+        """
+        actual test verification
+        """
+        result = True
+
+        step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
+        with step1.scope():
+            if not self.group.fw_update_ifc.ctam_fw_update_precheck():
+                step1.add_log(LogSeverity.INFO, f"{self.test_id} : FW Update Capable")
+            else:
+                step1.add_log(
+                    LogSeverity.INFO, f"{self.test_id} : FW Update Not Required"
+                )
+
+        step2 = self.test_run().add_step(f"{self.__class__.__name__} run(), step2")  # type: ignore
+        with step2.scope():
+            if self.group.fw_update_ifc.ctam_stage_fw(check_time=True):
+                step2.add_log(LogSeverity.INFO, f"{self.test_id} : FW Update Staged")
+            else:
+                step2.add_log(
+                    LogSeverity.ERROR, f"{self.test_id} : FW Update Stage Failed"
+                )
+                result = False
+
+        # ensure setting of self.result and self.score prior to calling super().run()
+        self.result = TestResult.PASS if result else TestResult.FAIL
+        if self.result == TestResult.PASS:
+            self.score = self.score_weight
+
+        # call super last to log result and score
+        super().run()
+        return self.result
+
+    def teardown(self):
+        """
+        undo environment state change from setup() above, this function is called even if run() fails or raises exception
+        """
+        # add custom teardown here
+        step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...step1")
+        with step1.scope():
+            if self.group.fw_update_ifc.ctam_activate_ac():
+                step1.add_log(
+                    LogSeverity.INFO, f"{self.test_id} : FW Update Activate"
+                )
+            else:
+                step1.add_log(
+                    LogSeverity.WARNING,
+                    f"{self.test_id} : FW Update Activation Failed",
+                )
+                result = False
+                    
+        if result:
+            step2 = self.test_run().add_step(f"{self.__class__.__name__} teardown()...step2")
+            with step2.scope():
+                if self.group.fw_update_ifc.ctam_fw_update_verify():
+                    step2.add_log(
+                        LogSeverity.INFO,
+                        f"{self.test_id} : Update Verification Completed",
+                    )
+                else:
+                    step2.add_log(
+                        LogSeverity.INFO, f"{self.test_id} : Update Verification Failed"
+                    )
+
+        # call super teardown last
+        super().teardown()

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_with_self_test.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_with_self_test.py
@@ -1,0 +1,125 @@
+"""
+Copyright (c) NVIDIA CORPORATION
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+
+:Test Name:		CTAM Test Full Device Update with Self-test Verification
+:Test ID:		F67
+:Group Name:	fw_update
+:Score Weight:	10
+
+:Description:	This test case does a full firmware update first, and then verifies if self-test reports any failures.
+:Usage 1:		python ctam.py -w ..\workspace -T F67
+:Usage 2:		python ctam.py -w ..\workspace -T "CTAM Test Full Device Update with Self-test Verification"
+
+"""
+
+from typing import Optional, List
+from tests.test_case import TestCase
+from ocptv.output import (
+    DiagnosisType,
+    LogSeverity,
+    SoftwareType,
+    TestResult,
+    TestStatus,
+)
+from tests.fw_update.fw_update_group_N._fw_update_group_N import (
+    FWUpdateTestGroupN,
+)
+from tests.fw_update.fw_update_group_N_1.ctam_test_full_device_update import (
+    CTAMTestFullDeviceUpdate,
+)
+from tests.health_check.basic_health_check_group.ctam_verify_self_test_report import (
+    CTAMVerifySelfTestReport,
+)
+from interfaces.health_check_ifc import (
+    HealthCheckIfc
+)
+
+
+class CTAMTestFullDeviceUpdateWithSelfTest(TestCase):
+    """
+    Verify if self-test reports any failure after a full firmware update
+
+    :param TestCase: super class for all test cases
+    :type TestCase:
+    """
+
+    test_name: str = "CTAM Test Full Device Update with Self-test Verification"
+    test_id: str = "F67"
+    score_weight: int = 10
+    tags: List[str] = []
+
+    def __init__(self, group: FWUpdateTestGroupN):
+        """
+        _summary_
+        """
+        super().__init__()
+        self.group = group
+
+    def setup(self):
+        """
+        set environment state for this test only
+        """
+        # call super first
+        super().setup()
+
+        # add custom setup here
+        step1 = self.test_run().add_step(f"{self.__class__.__name__}  setup()...")
+        with step1.scope():
+            pass
+
+    def run(self) -> TestResult:
+        """
+        actual test verification
+        """
+        result = True
+        fw_update_score_percentage = 0
+        self_test_score_percentage = 0
+        
+        step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
+        with step1.scope():
+            FwUpdateTest = CTAMTestFullDeviceUpdate(self.group)
+            if FwUpdateTest.run() == TestResult.PASS:
+                fw_update_score_percentage = float(FwUpdateTest.score / FwUpdateTest.score_weight)
+                step1.add_log(LogSeverity.INFO, f"{self.test_id} : FW Update")
+            else:
+                step1.add_log(
+                    LogSeverity.ERROR, f"{self.test_id} : FW Update Failed"
+                )
+                result = False
+
+        if result:
+            step2 = self.test_run().add_step(f"{self.__class__.__name__} run(), step2")  # type: ignore
+            with step2.scope():
+                self.group.health_check_ifc = HealthCheckIfc.get_instance()
+                SelfTest = CTAMVerifySelfTestReport(self.group)
+                if SelfTest.run() == TestResult.PASS:
+                    self_test_score_percentage = float(SelfTest.score / SelfTest.score_weight)
+                    step2.add_log(LogSeverity.INFO, f"{self.test_id} : Post FW Update Self-test")
+                else:
+                    step2.add_log(
+                        LogSeverity.ERROR, f"{self.test_id} : Post FW Update Self-test Failed"
+                    )
+                    result = False
+
+        # ensure setting of self.result and self.score prior to calling super().run()
+        self.result = TestResult.PASS if result else TestResult.FAIL
+        if self.result == TestResult.PASS:
+            self.score = (fw_update_score_percentage * 0.5 + self_test_score_percentage * 0.5) * self.score_weight
+
+        # call super last to log result and score
+        super().run()
+        return self.result
+
+    def teardown(self):
+        """
+        undo environment state change from setup() above, this function is called even if run() fails or raises exception
+        """
+        # add custom teardown here
+        step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
+        with step1.scope():
+            pass
+
+        # call super teardown last
+        super().teardown()

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_empty_metadata_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_empty_metadata_image_update.py
@@ -68,27 +68,31 @@ class CTAMTestNegativeEmptyMetadataImageUpdate(TestCase):
         """
         result = True
         
-        corrupted_component_id, corrupted_component_name = self.group.fw_update_ifc.ctam_get_component_to_be_corrupted()
-        
-        step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1_{corrupted_component_name}")  # type: ignore
+        step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
         with step1.scope():
-            if self.group.fw_update_ifc.ctam_selectpartiallist(count=1, specific_targets=[corrupted_component_name]):
-                step1.add_log(LogSeverity.INFO, f"{self.test_id} : Single Device Selected")
+            corrupted_component_id  = self.group.fw_update_ifc.ctam_get_component_to_be_corrupted()
+            corrupted_component_list = self.group.fw_update_ifc.ctam_get_component_list(component_id=corrupted_component_id)
+            step1.add_log(LogSeverity.INFO, f"{self.test_id} : Selected component to corrupt -> {corrupted_component_id}")
+        
+        step2 = self.test_run().add_step(f"{self.__class__.__name__} run(), step2_{corrupted_component_list[0]}")  # type: ignore
+        with step2.scope():
+            if self.group.fw_update_ifc.ctam_selectpartiallist(count=1, specific_targets=[corrupted_component_list[0]]):
+                step2.add_log(LogSeverity.INFO, f"{self.test_id} : Single Device Selected")
             else:
-                step1.add_log(LogSeverity.ERROR, f"{self.test_id} : Single Device Selection Failed")
+                step2.add_log(LogSeverity.ERROR, f"{self.test_id} : Single Device Selection Failed")
                 result = False
 
-        step2 = self.test_run().add_step(f"{self.__class__.__name__} run(), step2_{corrupted_component_name}")  # type: ignore
-        with step2.scope():
+        step3 = self.test_run().add_step(f"{self.__class__.__name__} run(), step3_{corrupted_component_list[0]}")  # type: ignore
+        with step3.scope():
             if self.group.fw_update_ifc.ctam_stage_fw(
                 partial=1, image_type="empty_metadata", corrupted_component_id=corrupted_component_id
             ):
-                step2.add_log(
+                step3.add_log(
                     LogSeverity.INFO,
                     f"{self.test_id} : FW Update Stage Initiation Failed as Expected",
                 )
             else:
-                step2.add_log(
+                step3.add_log(
                     LogSeverity.ERROR,
                     f"{self.test_id} : FW Update Staging Initiated - Unexpected",
                 )

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_empty_metadata_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_empty_metadata_image_update.py
@@ -1,0 +1,119 @@
+"""
+Copyright (c) NVIDIA CORPORATION
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+
+:Test Name:		CTAM Test Negative Empty Metadata Image Update
+:Test ID:		F26
+:Group Name:	fw_update
+:Score Weight:	10
+
+:Description:	This test case is a Negative Test. It'll make a copy of the default FW image provided in package_info.json 
+                and clear metadat of any component in the PLDM bundle. Then it'll attempt firmware update with the fwpkg containing corrupted UUID. 
+
+:Usage 1:		python ctam.py -w ..\workspace -t F26
+:Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Negative Empty Metadata Image Update"
+
+"""
+
+from typing import Optional, List
+from tests.test_case import TestCase
+from ocptv.output import (
+    DiagnosisType,
+    LogSeverity,
+    SoftwareType,
+    TestResult,
+    TestStatus,
+)
+from tests.fw_update.fw_update_group_N._fw_update_group_N import (
+    FWUpdateTestGroupN,
+)
+
+
+class CTAMTestNegativeEmptyMetadataImageUpdate(TestCase):
+    """
+    Verify values of Software Inventory Collection are present
+
+    :param TestCase: super class for all test cases
+    :type TestCase:
+    """
+
+    test_name: str = "CTAM Test Negative Empty Metadata Image Update"
+    test_id: str = "F26"
+    score_weight: int = 10
+    tags: List[str] = []
+
+    def __init__(self, group: FWUpdateTestGroupN):
+        """
+        _summary_
+        """
+        super().__init__()
+        self.group = group
+
+    def setup(self):
+        """
+        set environment state for this test only
+        """
+        # call super first
+        super().setup()
+
+        # add custom setup here
+        step1 = self.test_run().add_step(f"{self.__class__.__name__}  setup()...")
+        with step1.scope():
+            pass
+
+    def run(self) -> TestResult:
+        """
+        actual test verification
+        """
+        result = True
+        
+        corrupted_component_id, corrupted_component_name = self.group.fw_update_ifc.ctam_get_component_to_be_corrupted()
+        
+        step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1_{corrupted_component_name}")  # type: ignore
+        with step1.scope():
+            if self.group.fw_update_ifc.ctam_selectpartiallist(count=1, specific_targets=[corrupted_component_name]):
+                step1.add_log(LogSeverity.INFO, f"{self.test_id} : Single Device Selected")
+            else:
+                step1.add_log(LogSeverity.ERROR, f"{self.test_id} : Single Device Selection Failed")
+                result = False
+
+        step2 = self.test_run().add_step(f"{self.__class__.__name__} run(), step2_{corrupted_component_name}")  # type: ignore
+        with step2.scope():
+            if self.group.fw_update_ifc.ctam_stage_fw(
+                partial=1, image_type="empty_metadata", corrupted_component_id=corrupted_component_id
+            ):
+                step2.add_log(
+                    LogSeverity.INFO,
+                    f"{self.test_id} : FW Update Stage Initiation Failed as Expected",
+                )
+            else:
+                step2.add_log(
+                    LogSeverity.ERROR,
+                    f"{self.test_id} : FW Update Staging Initiated - Unexpected",
+                )
+                result = False
+
+        # ensure setting of self.result and self.score prior to calling super().run()
+        self.result = TestResult.PASS if result else TestResult.FAIL
+        if self.result == TestResult.PASS:
+            self.score = self.score_weight
+
+        # call super last to log result and score
+        super().run()
+        return self.result
+
+    def teardown(self):
+        """
+        undo environment state change from setup() above, this function is called even if run() fails or raises exception
+        """
+        # add custom teardown here
+        step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
+        with step1.scope():
+            if self.group.fw_update_ifc.ctam_pushtargets():
+                step1.add_log(LogSeverity.INFO, f"{self.test_id} : Push URI Targets Reset")
+            else:
+                step1.add_log(LogSeverity.WARNING, f"{self.test_id} : Push URI Targets Reset - Failed")
+
+        # call super teardown last
+        super().teardown()

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_uuid_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_uuid_image_update.py
@@ -1,0 +1,105 @@
+"""
+Copyright (c) NVIDIA CORPORATION
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+
+:Test Name:		CTAM Test Negative Invalid UUID Image Update
+:Test ID:		F27
+:Group Name:	fw_update
+:Score Weight:	10
+
+:Description:	This test case is a Negative Test. It'll make a copy of the default FW image provided in package_info.json 
+                and corrput the UUID of the PLDM bundle. Then it'll attempt firmware update with the fwpkg containing corrupted UUID. 
+
+:Usage 1:		python ctam.py -w ..\workspace -t F27
+:Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Negative Invalid UUID Image Update"
+
+"""
+
+from typing import Optional, List
+from tests.test_case import TestCase
+from ocptv.output import (
+    DiagnosisType,
+    LogSeverity,
+    SoftwareType,
+    TestResult,
+    TestStatus,
+)
+from tests.fw_update.fw_update_group_N._fw_update_group_N import (
+    FWUpdateTestGroupN,
+)
+
+
+class CTAMTestNegativeInvalidUUIDImageUpdate(TestCase):
+    """
+    Verify values of Software Inventory Collection are present
+
+    :param TestCase: super class for all test cases
+    :type TestCase:
+    """
+
+    test_name: str = "CTAM Test Negative Invalid UUID Image Update"
+    test_id: str = "F27"
+    score_weight: int = 10
+    tags: List[str] = []
+
+    def __init__(self, group: FWUpdateTestGroupN):
+        """
+        _summary_
+        """
+        super().__init__()
+        self.group = group
+
+    def setup(self):
+        """
+        set environment state for this test only
+        """
+        # call super first
+        super().setup()
+
+        # add custom setup here
+        step1 = self.test_run().add_step(f"{self.__class__.__name__}  setup()...")
+        with step1.scope():
+            pass
+
+    def run(self) -> TestResult:
+        """
+        actual test verification
+        """
+        result = True
+        step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
+        with step1.scope():
+            if self.group.fw_update_ifc.ctam_stage_fw(
+                partial=1, image_type="invalid_uuid"
+            ):
+                step1.add_log(
+                    LogSeverity.INFO,
+                    f"{self.test_id} : FW Update Stage Initiation Failed as Expected",
+                )
+            else:
+                step1.add_log(
+                    LogSeverity.ERROR,
+                    f"{self.test_id} : FW Update Staging Initiated - Unexpected",
+                )
+                result = False
+
+        # ensure setting of self.result and self.score prior to calling super().run()
+        self.result = TestResult.PASS if result else TestResult.FAIL
+        if self.result == TestResult.PASS:
+            self.score = self.score_weight
+
+        # call super last to log result and score
+        super().run()
+        return self.result
+
+    def teardown(self):
+        """
+        undo environment state change from setup() above, this function is called even if run() fails or raises exception
+        """
+        # add custom teardown here
+        step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
+        with step1.scope():
+            pass
+
+        # call super teardown last
+        super().teardown()

--- a/ctam/tests/health_check/basic_health_check_group/ctam_verify_self_test_report.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_verify_self_test_report.py
@@ -1,0 +1,114 @@
+"""
+Copyright (c) NVIDIA CORPORATION
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+
+:Test Name:		CTAM Test Verify Self-Test Report
+:Test ID:		H50
+:Group Name:	health_check
+:Score Weight:	10
+
+:Description:	This test case verifies if self-test reports any failures.
+:Usage 1:		python ctam.py -w ..\workspace -T H50
+:Usage 2:		python ctam.py -w ..\workspace -T "CTAM Test Verify Self-Test Report"
+
+"""
+from typing import Optional, List
+from tests.test_case import TestCase
+from ocptv.output import (
+    DiagnosisType,
+    LogSeverity,
+    SoftwareType,
+    TestResult,
+    TestStatus,
+)
+from tests.health_check.basic_health_check_group.basic_health_check_test_group import (
+    BasicHealthCheckTestGroup,
+)
+
+
+class CTAMVerifySelfTestReport(TestCase):
+    """
+    Verify if self-test reports any failures
+
+    :param TestCase: super class for all test cases
+    :type TestCase:
+    """
+
+    test_name: str = "CTAM Test Verify Self-Test Report"
+    test_id: str = "H50"
+    score_weight: int = 10
+    tags: List[str] = ["HCheck"]
+
+    def __init__(self, group: BasicHealthCheckTestGroup):
+        """
+        _summary_
+        """
+        super().__init__()
+        self.group = group
+
+    def setup(self):
+        """
+        set environment state for this test only
+        """
+        # call super first
+        super().setup()
+
+        # add custom setup here
+        step1 = self.test_run().add_step(f"{self.__class__.__name__}  setup()...")
+        with step1.scope():
+            pass
+
+    def run(self) -> TestResult:
+        """
+        actual test verification
+        """
+        result = True
+        
+        step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
+        with step1.scope():
+            if self.group.health_check_ifc.trigger_self_test_dump_collection():
+                step1.add_log(LogSeverity.INFO, f"{self.test_id} : Self test dump collection is triggered")
+            else:
+                step1.add_log(LogSeverity.ERROR, f"{self.test_id} : Self Test Dump Collection Failed")
+                result = False
+
+        if result:
+            step2 = self.test_run().add_step(f"{self.__class__.__name__} step2")  # type: ignore
+            with step2.scope():
+                if self.group.health_check_ifc.download_self_test_dump():
+                    step2.add_log(LogSeverity.INFO, f"{self.test_id} : Self Test Dump Download")
+                else:
+                    step2.add_log(LogSeverity.ERROR, f"{self.test_id} : Self Test Dump Download Failed")
+                    result = False
+                    
+        if result:
+            step3 = self.test_run().add_step(f"{self.__class__.__name__} run(), step3")  # type: ignore
+            with step3.scope():
+                if self.group.health_check_ifc.check_self_test_report():
+                    step3.add_log(LogSeverity.INFO, f"{self.test_id} : Self Test Report Failure Check")
+                else:
+                    step3.add_log(LogSeverity.ERROR, f"{self.test_id} : Self Test Report Failure Check Failed")
+                    result = False
+
+        # ensure setting of self.result and self.score prior to calling super().run()
+        self.result = TestResult.PASS if result else TestResult.FAIL
+        if self.result == TestResult.PASS:
+            self.score = self.score_weight
+
+        # call super last to log result and score
+        super().run()
+        return self.result
+
+    def teardown(self):
+        """
+        undo environment state change from setup() above, this function is called even if run() fails or raises exception
+        """
+        # add custom teardown here
+        step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
+        with step1.scope():
+            pass
+
+        # call super teardown last
+        super().teardown()

--- a/ctam/utils/fwpkg_utils.py
+++ b/ctam/utils/fwpkg_utils.py
@@ -1,0 +1,606 @@
+"""
+Copyright (c) NVIDIA CORPORATION
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+
+:Description:        This file holds all the useful firmware package manipulators. 
+
+:Command line:       Library functions are made as generic as possible.
+
+"""
+
+import os
+import shutil
+import uuid
+import math
+
+class PLDMFwpkg:
+    """
+    Methods related to PLDM fwpkg in general
+    """
+    
+    @staticmethod
+    def corrupt_package_UUID(golden_fwpkg_path):
+        """
+        :Description:                       Corrupt the PackageHeaderIdentifier (UUID) of the .
+
+        :param str golden_fwpkg_path:	    Path to golden firmware package
+
+        :returns:                           Path to corrupted package. None if corruption fails. 
+        :rtype:                             str
+        """
+        # Make a copy of the golden fwpkg
+        corrupted_package =  os.path.join(os.path.dirname(golden_fwpkg_path), "corrupted-pkg.fwpkg")
+        corrupted_package_path = shutil.copy(golden_fwpkg_path, corrupted_package)
+        try:
+            with open(corrupted_package_path, 'r+b') as file:
+                file.write(bytearray(16)) # UUID is 16 bytes
+        except Exception as e:
+            print(f"Error in corrupting the package: {e}")
+            # delete the package
+            os.remove(corrupted_package_path)
+            corrupted_package_path = None
+            
+        return corrupted_package_path
+
+    @staticmethod
+    def clear_component_metadata_in_pkg(golden_fwpkg_path, component_id=None, metadata_size=1024):
+        """
+        :Description:                       Clear metadata of any component in the PLDM bundle.
+                                            If component_id is provided, corrupt the respective component's image.
+
+        :param str golden_fwpkg_path:	    Path to golden firmware package
+        :param int component_id:            ComponentIdentifier of the component image to be corrupted. Default is None.
+        :param int metadata_size:           Metadata size in bytes. Default is 1024 bytes.
+
+        :returns:                           Path to corrupted package. None if corruption fails. 
+        :rtype:                             str
+        """
+        # Make a copy of the golden fwpkg
+        corrupted_package =  os.path.join(os.path.dirname(golden_fwpkg_path), "corrupted-pkg.fwpkg")
+        corrupted_package_path = shutil.copy(golden_fwpkg_path, corrupted_package)
+        
+        pldm_parser = PLDMUnpack()
+        if result := pldm_parser.parse_pldm_package(corrupted_package_path):
+            result = pldm_parser.corrupt_component_metadata_in_pkg(corrupted_package_path, component_id, metadata_size)
+            
+        if not result:
+            print(f"Error in corrupting the package.")
+            # delete the package
+            os.remove(corrupted_package_path)
+            corrupted_package_path = None
+            
+        return corrupted_package_path
+    
+    @staticmethod
+    def clear_component_image_in_pkg(golden_fwpkg_path, component_id=None):
+        """
+        :Description:                       Clear image/payload of any component in the PLDM bundle.
+                                            If component_id is provided, corrupt the respective component's image.
+
+        :param str golden_fwpkg_path:	    Path to golden firmware package
+        :param int component_id:            ComponentIdentifier of the component image to be corrupted. Default is None.
+
+        :returns:                           Path to corrupted package. None if corruption fails. 
+        :rtype:                             str
+        """
+        # Make a copy of the golden fwpkg
+        corrupted_package =  os.path.join(os.path.dirname(golden_fwpkg_path), "corrupted-pkg.fwpkg")
+        corrupted_package_path = shutil.copy(golden_fwpkg_path, corrupted_package)
+        
+        pldm_parser = PLDMUnpack()
+        if pldm_parser.parse_pldm_package(corrupted_package_path):
+            # Once unpacked, clear metadata of any component
+            pldm_parser.clear_component_image_in_pkg(corrupted_package_path, component_id)
+        else:
+            print(f"Error in corrupting the package.")
+            # delete the package
+            os.remove(corrupted_package_path)
+            corrupted_package_path = None
+            
+        return corrupted_package_path
+
+class FwpkgSignature:
+    """
+    Methods related to PLDM fwpkg signature
+    """
+    NUM_BYTES_FROM_END = 1024
+    HeaderV2 = 2
+    HeaderV3 = 3
+    
+    @staticmethod
+    def get_major_minor_version_of_package_signature(package_path):
+        """
+        :Description:                       Get the major and minor version of the FW Update Package Signature Format.
+
+        :param str fwpkg_path:      	    Path to firmware package
+        
+        :returns:                           The major and minor versions extracted from the package. (-1, -1) in case of failure.
+        :rtype:                             Tuple[int, int]
+        """
+        try:
+            with open(package_path, 'rb') as infile:
+                infile.seek(-FwpkgSignature.NUM_BYTES_FROM_END, os.SEEK_END)
+                infile.seek(4, 1)
+                major_version = infile.read(1)
+                minor_version = infile.read(1)
+
+            return ord(major_version), ord(minor_version)
+        except:
+            return -1, -1
+
+    @staticmethod
+    def corrupt_single_byte_in_package_signature(fwpkg_path, skip_byte, value):
+        """
+        :Description:                       Corrupt a given single byte in the given FW package.
+
+        :param str fwpkg_path:      	    Path to firmware package to be corrupted
+        :param int skip_byte:               The offset of the byte to be corrupted from the start of signature header
+        :param int value:                   The new value of the byte to be written
+
+        :returns:                           True if the corruption was successful, False otherwise.
+        :rtype:                             bool
+        """
+        try:
+            with open(fwpkg_path, 'r+b') as file:
+                file.seek(-FwpkgSignature.NUM_BYTES_FROM_END + skip_byte, os.SEEK_END)
+                file.write(bytes([value]))
+            return True
+        except Exception as e:
+            print(f"Error in corrupting the package: {e}")
+            return False
+        
+    @staticmethod
+    def corrupt_signature_type_in_package(golden_fwpkg_path):
+        """
+        :Description:                       Corrupts the signature type in the FW package, 
+                                            which is present at 14th byte from the start of signature header.
+
+        :param str golden_fwpkg_path:	    Path to golden firmware package
+
+        :returns:                           Path to corrupted package. None if corruption fails. 
+        :rtype:                             str
+        """
+        major_package_version, _ = get_major_minor_version_of_package_signature(golden_fwpkg_path)
+        if int(major_package_version) not in [FwpkgSignature.HeaderV2, FwpkgSignature.HeaderV3]:
+            print(
+                f"Package Major Version is not supported: {major_package_version}"
+            )
+            return None
+        
+        # Make a copy of the golden fwpkg
+        corrupted_package =  os.path.join(os.path.dirname(golden_fwpkg_path), "corrupted-pkg.fwpkg")
+        corrupted_package_path = shutil.copy(golden_fwpkg_path, corrupted_package)
+        
+        if not corrupt_single_byte_in_package_signature(corrupted_package_path, 13, 255):
+            print("Failed to corrupt the signature type")
+            # delete the package
+            os.remove(corrupted_package_path)
+            corrupted_package_path = None
+        return corrupted_package_path
+
+    @staticmethod
+    def invalidate_signature_in_pkg(golden_fwpkg_path):
+        """
+        :Description:                       Corrupts the magic number in the FW package, 
+                                            which is present at 14th byte from the start of signature header.
+
+        :param str golden_fwpkg_path:	    Path to golden firmware package
+
+        :returns:                           Path to corrupted package. None if corruption fails. 
+        :rtype:                             str
+        """
+        # Make a copy of the golden fwpkg
+        corrupted_package =  os.path.join(os.path.dirname(golden_fwpkg_path), "corrupted-pkg.fwpkg")
+        corrupted_package_path = shutil.copy(golden_fwpkg_path, corrupted_package)
+        
+        try:
+            with open(corrupted_package_path, 'r+b') as file:
+                file.seek(-FwpkgSignature.NUM_BYTES_FROM_END, os.SEEK_END)
+                file.write(bytearray(4)) # 4 bytes long Magic
+        except Exception as e:
+            print(f"Error in corrupting the package: {e}")
+            # delete the package
+            os.remove(corrupted_package_path)
+            corrupted_package_path = None
+        return corrupted_package_path
+
+    @staticmethod
+    def clear_signature_in_pkg(golden_fwpkg_path):
+        """
+        :Description:                       Clear the signature data appended at the end of
+                                            the PLDM bundle.
+
+        :param str golden_fwpkg_path:	    Path to golden firmware package
+
+        :returns:                           Path to corrupted package. None if corruption fails. 
+        :rtype:                             str
+        """
+        # Make a copy of the golden fwpkg
+        corrupted_package =  os.path.join(os.path.dirname(golden_fwpkg_path), "corrupted-pkg.fwpkg")
+        corrupted_package_path = shutil.copy(golden_fwpkg_path, corrupted_package)
+        try:
+            with open(corrupted_package_path, 'r+b') as file:
+                file.seek(-FwpkgSignature.NUM_BYTES_FROM_END, os.SEEK_END)
+                file.write(bytearray(FwpkgSignature.NUM_BYTES_FROM_END))
+        except Exception as e:
+            print(f"Error in corrupting the package: {e}")
+            # delete the package
+            os.remove(corrupted_package_path)
+            corrupted_package_path = None
+            
+        return corrupted_package_path
+
+class PLDMUnpack:
+    """
+    PLDMUnpack class implements a PLDM parser and the unpack tool
+    along with its required features.
+    """
+    def __init__(self):
+        """
+        Contructor for PLDMUnpack class
+        """
+        self.unpack = True
+        self.package = ""
+        self.fwpkg_fd = 0
+        self.header_map = {}
+        self.device_id_record_count = 0
+        self.fd_id_record_list = []
+        self.component_img_info_list = []
+        self.full_header = {
+            "PackageHeaderInformation": {},
+            "FirmwareDeviceIdentificationArea": {},
+            "ComponentImageInformationArea": {},
+            "Package Header Checksum": ''
+        }
+        self.verbose = False
+        self.little_endian_list = [
+            "IANA Enterprise ID", "PCI Vendor ID", "PCI Device ID",
+            "PCI Subsystem Vendor ID", "PCI Subsystem ID"
+        ]
+
+    def parse_header(self):
+        """
+        :Description:                       Parse PLDM header data into self.header_map
+
+        :returns:                           True if parsing successful
+        :rtype:                             bool
+        """
+        # check if UUID is valid
+        pldm_fw_header_id_v1_0 = b'\xf0\x18\x87\x8c\xcb\x7d\x49\x43\x98\x00\xa0\x2f\x05\x9a\xca\x02'
+        uuid_v1_0 = str(uuid.UUID(bytes=pldm_fw_header_id_v1_0))
+        self.header_map["PackageHeaderIdentifier"] = str(
+            uuid.UUID(bytes=self.fwpkg_fd.read(16)))
+        if uuid_v1_0 != self.header_map["PackageHeaderIdentifier"]:
+            log_msg = "Expected PLDM v1.0 but PackageHeaderIdentifier is "\
+            + self.header_map["PackageHeaderIdentifier"]
+            print(log_msg)
+            return False
+        self.header_map["PackageHeaderFormatVersion"] = str(
+            int.from_bytes(self.fwpkg_fd.read(1),
+                           byteorder='little',
+                           signed=False))
+        self.header_map["PackageHeaderSize"] = int.from_bytes(
+            self.fwpkg_fd.read(2), byteorder='little', signed=False)
+        timestamp = self.fwpkg_fd.read(13)
+        self.header_map["PackageReleaseDateTime"] = get_timestamp_str(
+            timestamp)
+        self.header_map["ComponentBitmapBitLength"] = int.from_bytes(
+            self.fwpkg_fd.read(2), byteorder='little', signed=False)
+        self.header_map["PackageVersionStringType"] = int.from_bytes(
+            self.fwpkg_fd.read(1), byteorder='little', signed=False)
+        version_str_len = int.from_bytes(self.fwpkg_fd.read(1),
+                                         byteorder='little',
+                                         signed=False)
+        self.header_map["PackageVersionStringLength"] = version_str_len
+        self.header_map["PackageVersionString"] = self.fwpkg_fd.read(
+            version_str_len).decode('utf-8')
+        self.full_header["PackageHeaderInformation"] = self.header_map
+        return True
+
+    def parse_device_id_records(self):
+        """
+        :Description:                       Parse PLDM FirmwareDeviceIDRecords data into self.fd_id_record_list
+
+        :returns:                           True if parsing successful
+        :rtype:                             bool
+        """
+        # pylint: disable=line-too-long
+        self.device_id_record_count = int.from_bytes(self.fwpkg_fd.read(1),
+                                                     byteorder='little',
+                                                     signed=False)
+        for _ in range(self.device_id_record_count):
+            id_record_map = {}
+            id_record_map["RecordLength"] = int.from_bytes(
+                self.fwpkg_fd.read(2), byteorder='little', signed=False)
+            id_record_map["DescriptorCount"] = int.from_bytes(
+                self.fwpkg_fd.read(1), byteorder='little', signed=False)
+            id_record_map["DeviceUpdateOptionFlags"] = int.from_bytes(
+                self.fwpkg_fd.read(4), byteorder='little', signed=False)
+            id_record_map[
+                "ComponentImageSetVersionStringType"] = int.from_bytes(
+                    self.fwpkg_fd.read(1), byteorder='little', signed=False)
+            id_record_map[
+                "ComponentImageSetVersionStringLength"] = int.from_bytes(
+                    self.fwpkg_fd.read(1), byteorder='little', signed=False)
+            id_record_map["FirmwareDevicePackageDataLength"] = int.from_bytes(
+                self.fwpkg_fd.read(2), byteorder='little', signed=False)
+            applicable_component_size = math.ceil(
+                self.header_map["ComponentBitmapBitLength"] / 8)
+            id_record_map["ApplicableComponents"] = int.from_bytes(
+                self.fwpkg_fd.read(applicable_component_size),
+                byteorder='little',
+                signed=False)
+            id_record_map[
+                "ComponentImageSetVersionString"] = self.fwpkg_fd.read(
+                    id_record_map["ComponentImageSetVersionStringLength"]
+                ).decode('utf-8')
+            descriptors = []
+            for j in range(id_record_map["DescriptorCount"]):
+                descriptor_map = {}
+                if j == 0:
+                    descriptor_map["InitialDescriptorType"] = int.from_bytes(
+                        self.fwpkg_fd.read(2),
+                        byteorder='little',
+                        signed=False)
+                    descriptor_map["InitialDescriptorLength"] = int.from_bytes(
+                        self.fwpkg_fd.read(2),
+                        byteorder='little',
+                        signed=False)
+                    value = self.fwpkg_fd.read(
+                        descriptor_map["InitialDescriptorLength"])
+                    descriptor_map["InitialDescriptorData"] = value
+
+                else:
+                    descriptor_map[
+                        "AdditionalDescriptorType"] = int.from_bytes(
+                            self.fwpkg_fd.read(2),
+                            byteorder='little',
+                            signed=False)
+                    descriptor_map[
+                        "AdditionalDescriptorLength"] = int.from_bytes(
+                            self.fwpkg_fd.read(2),
+                            byteorder='little',
+                            signed=False)
+                    if descriptor_map["AdditionalDescriptorType"] == 0xFFFF:
+                        descriptor_map[
+                            "VendorDefinedDescriptorTitleStringType"] = int.from_bytes(
+                                self.fwpkg_fd.read(1),
+                                byteorder='little',
+                                signed=False)
+                        descriptor_map[
+                            "VendorDefinedDescriptorTitleStringLength"] = int.from_bytes(
+                                self.fwpkg_fd.read(1),
+                                byteorder='little',
+                                signed=False)
+                        descriptor_map[
+                            "VendorDefinedDescriptorTitleString"] = self.fwpkg_fd.read(
+                                descriptor_map[
+                                    "VendorDefinedDescriptorTitleStringLength"]
+                            ).decode('utf-8')
+                        vendor_def_data_len = (
+                            descriptor_map["AdditionalDescriptorLength"] -
+                            (2 + descriptor_map[
+                                "VendorDefinedDescriptorTitleStringLength"]))
+                        descriptor_map[
+                            "VendorDefinedDescriptorData"] = self.fwpkg_fd.read(
+                                vendor_def_data_len).hex()
+                    else:
+                        descriptor_map[
+                            "AdditionalDescriptorIdentifierData"] = self.fwpkg_fd.read(
+                                descriptor_map["AdditionalDescriptorLength"])
+                descriptors.append(descriptor_map)
+            id_record_map["RecordDescriptors"] = descriptors
+            id_record_map["FirmwareDevicePackageData"] = self.fwpkg_fd.read(
+                id_record_map["FirmwareDevicePackageDataLength"]).decode(
+                    'utf-8')
+            self.fd_id_record_list.append(id_record_map)
+        self.full_header["FirmwareDeviceIdentificationArea"] = {
+            "DeviceIDRecordCount": self.device_id_record_count,
+            "FirmwareDeviceIDRecords": self.fd_id_record_list
+        }
+        return True
+
+    def parse_component_img_info(self):
+        """
+        :Description:                       Parse PLDM Component Image info data into self.fd_id_record_list
+
+        :returns:                           True if parsing successful
+        :rtype:                             bool
+        """
+        component_image_count = int.from_bytes(self.fwpkg_fd.read(2),
+                                               byteorder='little',
+                                               signed=False)
+        for _ in range(component_image_count):
+            comp_info = {}
+            comp_info["ComponentClassification"] = int.from_bytes(
+                self.fwpkg_fd.read(2), byteorder='little', signed=False)
+            comp_info["ComponentIdentifier"] = hex(
+                int.from_bytes(self.fwpkg_fd.read(2),
+                               byteorder='little',
+                               signed=False))
+            comp_info["ComponentComparisonStamp"] = int.from_bytes(
+                self.fwpkg_fd.read(4), byteorder='little', signed=False)
+            comp_info["ComponentOptions"] = int.from_bytes(
+                self.fwpkg_fd.read(2), byteorder='little', signed=False)
+            comp_info["RequestedComponentActivationMethod"] = int.from_bytes(
+                self.fwpkg_fd.read(2), byteorder='little', signed=False)
+            # RequestedComponentActivationMethod can have any combination of bits 0:5 set
+            # Any value above 0x3F is invalid
+            activation_val = comp_info["RequestedComponentActivationMethod"]
+            if activation_val > 0x3F:
+                Util.cli_log(
+                    f"Found invalid value for RequestedComponentActivationMethod={activation_val}",
+                    True)
+            comp_info["ComponentLocationOffset"] = int.from_bytes(
+                self.fwpkg_fd.read(4), byteorder='little', signed=False)
+            comp_info["ComponentSize"] = int.from_bytes(self.fwpkg_fd.read(4),
+                                                        byteorder='little',
+                                                        signed=False)
+            comp_info["ComponentVersionStringType"] = int.from_bytes(
+                self.fwpkg_fd.read(1), byteorder='little', signed=False)
+            comp_info["ComponentVersionStringLength"] = int.from_bytes(
+                self.fwpkg_fd.read(1), byteorder='little', signed=False)
+            comp_info["ComponentVersionString"] = self.fwpkg_fd.read(
+                comp_info["ComponentVersionStringLength"]).decode('utf-8')
+            self.component_img_info_list.append(comp_info)
+        self.full_header["ComponentImageInformationArea"] = {
+            "ComponentImageCount": component_image_count,
+            "ComponentImageInformation": self.component_img_info_list
+        }
+        return True
+    
+    def get_pldm_header_checksum(self):
+        """
+        :Description:                       Read PLDM header checksum
+
+        :returns:                           None
+        :rtype:                             None
+        """
+        self.full_header['Package Header Checksum'] = int.from_bytes(
+            self.fwpkg_fd.read(4), byteorder='little', signed=False)
+
+    def parse_pldm_package(self, package_name):
+        """
+        :Description:                       Parse the PLDM package and get information about components included in the FW image.
+        
+        :param str package_name:	        Path to the firmware package to be parsed
+        
+        :returns:                           True if parsing successful
+        :rtype:                             bool
+        """
+        if package_name == "" or package_name is None:
+            log_msg = "ERROR: Firmware package file is mandatory."
+            print(log_msg)
+            return False
+        if os.path.exists(package_name) is False:
+            log_msg = print("ERROR: File does not exist at path ",
+                            package_name)
+            print(log_msg)
+            return False
+        self.package = package_name
+        try:
+            with open(self.package, "rb") as self.fwpkg_fd:
+                parsing_valid = self.parse_header()
+                if parsing_valid:
+                    parsing_valid = self.parse_device_id_records()
+                    if parsing_valid:
+                        parsing_valid = self.parse_component_img_info()
+                        self.get_pldm_header_checksum()
+            return parsing_valid
+        except IOError as e_io_error:
+            log_message = f"Couldn't open or read given FW package ({e_io_error})"
+            print(log_message)
+            return False
+        
+    def corrupt_component_metadata_in_pkg(self, fwpkg_path, component_id=None, metadata_size=1024):
+        """
+        :Description:                       Corrupt a component's metadata in the given FW package.
+                                            If component_id is provided, corrupt the respective component's image.
+                                            Otherwise, corrupt the first component image in the package.
+    
+        :param str fwpkg_path:      	    Path to firmware package to be corrupted
+        :param int component_id:            ComponentIdentifier (in hex format) of the component image to be corrupted. Default is None.
+        :param int metadata_size:           Metadata size in bytes. Default is 1024 bytes.
+
+        :returns:                           True if the corruption was successful, False otherwise.
+        :rtype:                             bool
+        """
+        corruption_status = False
+        package_size = os.path.getsize(fwpkg_path)
+        for index, info in enumerate(self.component_img_info_list):
+            if component_id is not None and info["ComponentIdentifier"] != component_id:
+                continue
+            # Lseek to the component from the PLDM fwpkg   
+            offset = info["ComponentLocationOffset"]
+            size = info["ComponentSize"]
+            if offset + size > package_size:
+                log_msg = f"Error: ComponentLocationOffset {offset} + \
+                ComponentSize {size} exceeds given package size {package_size}"
+                print(log_msg)
+                break
+            print(f"Corrupting metadata of component: {self.component_img_info_list[index]}")
+            try:
+                with open(self.package, 'r+b') as self.fwpkg_fd:
+                    self.fwpkg_fd.seek(offset)
+                    # Zero out metadata bytes
+                    # Save the bundle
+                    self.fwpkg_fd.write(bytearray(metadata_size))
+                    corruption_status = True
+                    break
+            except IOError as e_io_error:
+                log_message = f"Couldn't open or read given FW package ({e_io_error})"
+                print(log_message)
+        return corruption_status
+            
+    def clear_component_image_in_pkg(self, fwpkg_path, component_id=None):
+        """
+        :Description:                       Clear a component's image/payload in the given FW package.
+                                            If component_id is provided, corrupt the respective component's image.
+                                            Otherwise, corrupt the first component image in the package.
+    
+        :param str fwpkg_path:      	    Path to firmware package to be corrupted
+        :param int component_id:            ComponentIdentifier of the component image to be corrupted. Default is None.
+
+        :returns:                           True if the corruption was successful, False otherwise.
+        :rtype:                             bool
+        """
+        package_size = os.path.getsize(fwpkg_path)
+        for index, info in enumerate(self.component_img_info_list):
+            if component_id is not None and info["ComponentIdentifier"] != hex(int(component_id)):
+                continue
+            # Lseek to the component from the PLDM fwpkg   
+            offset = info["ComponentLocationOffset"]
+            size = info["ComponentSize"]
+            if offset + size > package_size:
+                log_msg = f"Error: ComponentLocationOffset {offset} + \
+                ComponentSize {size} exceeds given package size {package_size}"
+                print(log_msg)
+                return False
+            try:
+                with open(self.package, 'r+b') as self.fwpkg_fd:
+                    self.fwpkg_fd.seek(offset)
+                    # Zero out that many bytes
+                    # Save the bundle
+                    self.fwpkg_fd.write(bytearray(size))
+                    break
+            except IOError as e_io_error:
+                log_message = f"Couldn't open or read given FW package ({e_io_error})"
+                print(log_message)
+                return False
+
+def get_timestamp_str(timestamp):
+    """
+    :Description:                       Parse timestamp string from 13 byte binary data
+                                        according to PLDM Base specification
+
+    :param str timestamp:      	        Timestamp bytes to be parsed
+    
+    :returns:                           Timestamp in PLDM base spec format
+    :rtype:                             str
+    """
+    year = timestamp[11]
+    year = year << 8
+    year = year | timestamp[10]
+    time_str = str(year) + "-"
+    time_str = time_str + str(timestamp[9])
+    time_str = time_str + "-" + str(timestamp[8])
+    time_str = time_str + " " + str(timestamp[7])
+    time_str = time_str + ":" + str(timestamp[6])
+    time_str = time_str + ":" + str(timestamp[5])
+    micro_sec = timestamp[4]
+    micro_sec = micro_sec << 8
+    micro_sec = micro_sec | timestamp[3]
+    micro_sec = micro_sec << 8
+    micro_sec = micro_sec | timestamp[2]
+    time_str = time_str + ":" + str(micro_sec)
+    utc_offset = timestamp[1]
+    utc_offset = utc_offset << 8
+    utc_offset = utc_offset | timestamp[0]
+    sign = "+"
+    if utc_offset < 0:
+        utc_offset = utc_offset * -1
+        sign = "-"
+    time_str = time_str + " " + sign + str(utc_offset)
+    return time_str
+

--- a/json_spec/input/dut_info.json
+++ b/json_spec/input/dut_info.json
@@ -83,6 +83,16 @@
       "description": "Options are GPU_BB & Discrete_GFX for now",
       "type": "string",
       "value": "GPU_BB"
+    },
+    "FwStagingTimeMax": {
+      "description": "Maximum time in seconds taken by staging (copy) phase of full device FW update",
+      "type": "int",
+      "value": 600
+    },
+    "FwActivationTimeMax": {
+      "description": "Maximum time in seconds taken by activation phase of full device FW update",
+      "type": "int",
+      "value": 600
     }
   },
   "required": [
@@ -92,6 +102,8 @@
     "PowerOnCommand",
     "DebugMode",
     "PowerOffWaitTime",
-    "PowerOnWaitTime"
+    "PowerOnWaitTime",
+    "FwStagingTimeMax",
+    "FwActivationTimeMax"
   ]
 }

--- a/json_spec/input/package_info.json
+++ b/json_spec/input/package_info.json
@@ -54,9 +54,9 @@
     "JSON": "",
     "Vendor": ""
   },
-  "GPU_FW_IMAGE_EMPTY_METADATA": {
+  "GPU_FW_IMAGE_CORRUPT_COMPONENT": {
     "CorruptComponentIdentifier": "",
-    "MetadataSizeBytes": 1024,
+    "MetadataSizeBytes": 4096,
     "Vendor": ""
   }
 }

--- a/json_spec/input/package_info.json
+++ b/json_spec/input/package_info.json
@@ -53,5 +53,10 @@
     "Version": "",
     "JSON": "",
     "Vendor": ""
+  },
+  "GPU_FW_IMAGE_EMPTY_METADATA": {
+    "CorruptComponentIdentifier": "",
+    "MetadataSizeBytes": 1024,
+    "Vendor": ""
   }
 }


### PR DESCRIPTION
- Added new firmware update testcases:
1. F67	Post firmware update, run GPU self test to ensure 0 failures
2. F26	Attempt single device update with empty meta data
3. F27	Attempt update with invalid UUID
4. F63	Firmware copy operation should not exceed the max time specified in the requirements
5. F64	Firmware activation operation should not exceed the max time specified in the requirements.
6. F24	Attempt update for a device while update is in progress
7. H50	Self-test report verification for no failure (as part of F67)
8. F55	Firmware Update Stack Robustness: One component copying (staging) fails and verify other component copying (staging) goes through.
9. F56	Firmware Update Stack Robustness: One component copying (staging) fails and verify activation is handled - Activation check (only the failed component will stick to the old firmware, but healthy)

- Added the functionality of corrupting a golden firmware package for negative testcases.
- Pinging the system IP before setting up ssh tunneling

Test Reports

- Following new testcases are added and tested in Nvidia system to verify expected behavior.

> - **Test#	- Description - Test result in Nvidia System**
> - F67	Post firmware update, run GPU self test to ensure 0 failures	- Pass
> - F26	Attempt single device update with empty meta data - Pass
> - F27	Attempt update with invalid UUID	- Pass
> - F63	Firmware copy operation should not exceed the max time specified in the requirements - Pass
> - F64	Firmware activation operation should not exceed the max time specified in the requirements - Pass
> - F24	Attempt update for a device while update is in progress  - Pass
> - H50	Self-test report verification for no failure (as part of F67) - Pass
> - F55	Firmware Update Stack Robustness: One component copying (staging) fails and verify other component copying (staging) goes through. - Pass
> - F56	Firmware Update Stack Robustness: One component copying (staging) fails and verify activation is handled - Activation check (only the failed component will stick to the old firmware, but healthy) - Pass


As part of regression test, following tests have been run as well:

> - **Test#	- Description - Test result in Nvidia System**
> - F1	Full Device Update - Pass
> - F23	Negative Corrupt Image Update - Pass
> - F25	Negative Large Image Update - Pass
> - F8	Full Device Update In Loop - Pass