### PR TITLE
Fix in health check testcases + Redfish Authentication + Misc. minor changes

### DIFF
--- a/ctam/interfaces/comptool_dut.py
+++ b/ctam/interfaces/comptool_dut.py
@@ -15,6 +15,7 @@ import subprocess
 import platform
 import json
 from datetime import datetime
+import traceback
 
 #import pandas as pd
 
@@ -109,11 +110,17 @@ class CompToolDut(Dut):
             username=self.__user_name,
             password=self.__user_pass,
             default_prefix=default_prefix,
+            timeout=30
         )
 
-        # self.redfish_ifc.login(auth="basic")   #TODO investigate 'session' token auth
+        if config["properties"].get("AuthenticationRequired", {}).get("value"):
+            self.redfish_auth = True
+            self.redfish_ifc.login(auth="basic")   #TODO investigate 'session' token auth
+            self.test_info_logger.log("Redfish login is successful.")
+        else:
+            self.redfish_auth = False
 
-    def run_redfish_command(self, uri, mode="GET", body=None, headers=None):
+    def run_redfish_command(self, uri, mode="GET", body=None, headers=None, timeout=None):
         """
         This method is for running redfish commands according to mode and log the ouput into
         a formatted log file and return the response
@@ -137,29 +144,42 @@ class CompToolDut(Dut):
                     "TestName": self.current_test_name,
                     "URI": uri,
             }
+            kwargs = {"path": uri, "headers": headers}
+            if timeout is not None:
+                kwargs.update({"timeout": timeout})
+                
             if mode == "POST":
-                msg.update({"Method":"POST","Data":"{}".format(body),}) # FIXME: It floods the logs. Do we need to log the entire body? 
-                response = self.redfish_ifc.post(path=uri, body=body, headers=headers)
+                msg.update({"Method":"POST"})
+                #msg.update({"Method":"POST","Data":"{}".format(body),}) # FIXME: It floods the logs. Do we need to log the entire body? 
+                kwargs.update({"body": body})
+                response = self.redfish_ifc.post(**kwargs)
+                #response = self.redfish_ifc.post(path=uri, body=body, headers=headers)
             elif mode == "PATCH":
                 msg.update({"Mode":"PATCH","Data":"{}".format(body),})
-                response = self.redfish_ifc.patch(path=uri, body=body, headers=headers)
+                kwargs.update({"body": body})
+                response = self.redfish_ifc.patch(**kwargs)
+                #response = self.redfish_ifc.patch(path=uri, body=body, headers=headers)
             elif mode == "GET":
                 msg.update({"Method":"GET",})
-                response = self.redfish_ifc.get(path=uri, headers=headers)
-            if response:
+                response = self.redfish_ifc.get(**kwargs)
+                #response = self.redfish_ifc.get(path=uri, headers=headers)
+            if response: # FIXME: Add error handling in case the request fails
                 msg.update({
                     "ResponseCode": response.status,
-                    "Response":response.dict,
+                    "Response":response.text,
                     })
             else:
                 msg.update({"Response":"Response is None please check the request you are trying to invoke."})
             # self.logger.write(json.dumps(msg))
-            return response
+            
         except Exception as e:
             print("FATAL: Exception occurred while running redfish command. Please see below exception...")
             print(str(e))
+            print(traceback.format_exc())
         finally:
             self.logger.write(json.dumps(msg))
+            
+        return response
 
     def check_uri_response(self, uri, response):
         if not self.test_uri_response_check:
@@ -229,16 +249,18 @@ class CompToolDut(Dut):
                     bmc_ip = self.connection_ip_address,
                     amc_ip = amc_ip_address,
                     )
-            process = subprocess.Popen(ssh_cmd, shell=True)
-            process.wait()
-            if process.returncode != 0 or process.stdout != None:
-                print(f"Failed to bind port {port}. Trying the next one...") # FIXME: Use logging method
+            process = subprocess.Popen(ssh_cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+            stdout_data, stderr_data = process.communicate()
+            if process.returncode != 0 or stderr_data:
+                msg = f"Failed to bind port {port}.\nReturnCode: {process.returncode}\nError: {stderr_data}\nTrying the next one..."
+                self.test_info_logger.log(msg)
             else:
                 self.BindedPort = port
                 break
         if self.BindedPort is None:
-            raise Exception(f"Failed to bind port! Please make sure the host machine has port forwarding enabled and there is at least one port avaailable in {PortList}.")
-        print(f"Binded port {self.BindedPort}") # FIXME: Use logging method
+            raise Exception(f"Failed to bind port! Please make sure the host machine has port forwarding enabled and there is at least one port available in {PortList}.")
+        msg = f"Binded port {self.BindedPort}"
+        self.test_info_logger.log(msg)
         return
     
     def kill_ssh_tunnel(self):
@@ -251,17 +273,21 @@ class CompToolDut(Dut):
             # Make sure to not kill this running process
             if int(this_pid) != my_pid:
                 kill_cmd = "kill {}".format(this_pid)
-                process = subprocess.Popen(kill_cmd, shell=True)
-                process.wait()
-                if process.returncode != 0 or process.stdout != None:
-                    print(f"WARNING: Couldn't close the port forwarding! {kill_cmd}") # FIXME: Use logging method
+                process = subprocess.Popen(kill_cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+                stdout_data, stderr_data = process.communicate()
+                if process.returncode != 0 or stderr_data:
+                    msg = f"WARNING: Couldn't close the port forwarding! {kill_cmd}\nReturnCode: {process.returncode}\nError: {stderr_data}"
+                    self.test_info_logger.log(msg)
                 else:
-                    print("SSH tunnel is killed successfully!") # FIXME: Use logging method
+                    self.test_info_logger.log("SSH tunnel is killed successfully!")
                     self.BindedPort = None # Just for sanity in case of multi-threading
                 
     def clean_up(self):
         if self.BindedPort:
             self.kill_ssh_tunnel()
+        if self.redfish_auth:
+            self.redfish_ifc.logout()
+            self.test_info_logger.log("Redfish logout is successful.")
 
     def check_ping_status(self, ip_address):
         p = '-n' if platform.system().lower()=='windows' else '-c'

--- a/ctam/interfaces/functional_ifc.py
+++ b/ctam/interfaces/functional_ifc.py
@@ -655,3 +655,32 @@ class FunctionalIfc:
                 "Message": message,
             }
         self.dut().test_info_logger.write(json.dumps(msg))
+        
+    def ctam_verify_expanded(self, JSONData):
+        """
+        :Description:					Check if the Redfish API response is expanded correctly (level 1)
+        
+        :param JSONData:                Redfish response in json/dictionary format
+        :type JSONData:                 dictionary
+        
+        :returns:				    	result (Pass/Fail)
+        :rtype: 						Bool
+        """
+        result = True
+        for element in JSONData:
+            # Simple dictionary
+            if type(JSONData[element]) == type(dict()) and ("@odata.id" in JSONData[element]):
+                if "@odata.type" not in JSONData[element]:
+                    self.test_run().add_log(LogSeverity.ERROR, f"{JSONData[element]} is not expanded.")
+                    result = False
+                    break
+            # List of dictionaries
+            elif type(JSONData[element]) == type([]):
+                for dictionary in JSONData[element]:
+                    if type(dictionary) == type(dict()) and ("@odata.id" in dictionary):
+                        if "@odata.type" not in dictionary:
+                            self.test_run().add_log(LogSeverity.ERROR, f"{dictionary} is not expanded.")
+                            result = False
+                            break
+        return result
+            

--- a/ctam/interfaces/fw_update_ifc.py
+++ b/ctam/interfaces/fw_update_ifc.py
@@ -96,8 +96,7 @@ class FWUpdateIfc(FunctionalIfc):
                 Package_Version = jsonhunt(
                     PLDMPkgJson,
                     "ComponentIdentifier",
-                    #str(hex(int(element["SoftwareId"], 16))),
-                    int(element["SoftwareId"], 16),
+                    str(hex(int(element["SoftwareId"], 16))),
                     "ComponentVersionString",
                 )
                 if Package_Version is None:
@@ -286,8 +285,7 @@ class FWUpdateIfc(FunctionalIfc):
                     ExpectedVersion = jsonhunt(
                         PLDMPkgJson,
                         "ComponentIdentifier",
-                        #str(hex(int(element["SoftwareId"], 16))),
-                        int(element["SoftwareId"], 16),
+                        str(hex(int(element["SoftwareId"], 16))),
                         "ComponentVersionString",
                     )
                 if (

--- a/ctam/interfaces/health_check_ifc.py
+++ b/ctam/interfaces/health_check_ifc.py
@@ -74,10 +74,10 @@ class HealthCheckIfc(FunctionalIfc):
             if self.dumplog_uri_list == []:
                 result = False
         for dumplog_uri in self.dumplog_uri_list:
-            clear_dump_uri = dumplog_uri + "/Actions/LogService.ClearLog" + " -d 0"
+            clear_dump_uri = dumplog_uri + "/Actions/LogService.ClearLog"
             print(clear_dump_uri)
-            uri = self.dut().uri_builder.format_uri(redfish_str="{GPUMC}", component_type="GPU")
-            self.dut().run_redfish_command(uri=uri)
+            uri = self.dut().uri_builder.format_uri(redfish_str="{GPUMC}" + "{}".format(clear_dump_uri), component_type="GPU")
+            self.dut().run_redfish_command(uri=uri, mode="POST")
         self.write_test_info("{}".format(result))
         return result
     

--- a/ctam/interfaces/health_check_ifc.py
+++ b/ctam/interfaces/health_check_ifc.py
@@ -24,10 +24,12 @@ class HealthCheckIfc(FunctionalIfc):
 
     def __init__(self):
         super().__init__()
-        self.logservice_uri_list = []
+        self.logservice_uri_list = [] # FIXME: May remove this list as we may retrieve this list from the dict whenever we need.
+        self.logservice_uri_dict = {}
         self.entries_uri_list = []
         self.eventlog_uri_list = []
-        self.dumplog_uri_list = []
+        self.dumplog_uri_list = [] # FIXME: May remove this list as we may retrieve this list from the dict whenever we need.
+        self.dumplog_uri_dict = {}
         self.journal_uri_list = []
 
     def __new__(cls, *args, **kwargs):
@@ -53,6 +55,50 @@ class HealthCheckIfc(FunctionalIfc):
             cls._instance = cls(*args, **kwargs)
         return cls._instance
     
+    def ctam_get_all_logservice_uris(self, resource_collection_list=["Systems", "Managers", "Chassis"]):
+        """
+        :Description:	                    Look for "LogService" URIs under specific resourcse collection.
+
+        :param resource_collection_list:    list of resource collectionsto check. Default is ["Systems", "Managers", "Chassis"]
+        :type resource_collection_list:     list
+        
+        :return:                            list of LogServices uri
+        :rtype:                             list
+        """
+        for resource_collection in resource_collection_list:
+            # Skip populating the list for this resource if it's present already
+            if resource_collection not in self.logservice_uri_dict:
+                URI = "/redfish/v1/" + resource_collection
+                logservice_uri_list = []
+                self.ctam_redfish_uri_deep_hunt(
+                    URI, "LogServices", logservice_uri_list
+                )
+                self.logservice_uri_dict[resource_collection] = logservice_uri_list
+                self.logservice_uri_list.extend(logservice_uri_list)
+        self.write_test_info("LogServices URI list: {}".format(self.logservice_uri_list))
+        return self.logservice_uri_list
+    
+    def ctam_verify_logservice_presence(self, resource_collection_list=["Systems", "Managers", "Chassis"]):
+        """
+        :Description:	                    Verify if "LogService" URIs is present under the specified resourcse collection.
+
+        :param resource_collection_list:    list of resource collectionsto check. Default is ["Systems", "Managers", "Chassis"]
+        :type resource_collection_list:     list
+        
+        :return:                            result (Pass/Fail)
+        :rtype:                             bool
+        """
+        result = True
+        if self.logservice_uri_dict == {}:
+            self.test_run().add_log(LogSeverity.ERROR, f"LogServices URI List is empty. Nothing to verify!")
+            result = False
+        else:
+            for resource_collection in resource_collection_list:
+                if resource_collection not in self.logservice_uri_dict or self.logservice_uri_dict[resource_collection] == []:
+                   self.test_run().add_log(LogSeverity.ERROR, f"Checking existing URI list - LogServices is not found in {resource_collection}")
+                   result = False
+        return result
+    
     def ctam_get_logservice_uris(self):
         if self.logservice_uri_list == []:
             self.ctam_redfish_uri_deep_hunt(
@@ -69,16 +115,19 @@ class HealthCheckIfc(FunctionalIfc):
 
     def ctam_clear_log_dump(self):
         result = True
-        if self.dumplog_uri_list == []:
-            self.dumplog_uri_list = self.ctam_get_logdump_uris()
+        if self.dumplog_uri_list == []: # FIXME: Should we use the dict instead?
+            self.dumplog_uri_list = self.ctam_get_logdump_uris() # FIXME: Should we use the ctam_get_all_logdump_uris instead?
             if self.dumplog_uri_list == []:
+                self.write_test_info("LogServices Dump URI list is empty. Nothing to clear!")
                 result = False
         for dumplog_uri in self.dumplog_uri_list:
             clear_dump_uri = dumplog_uri + "/Actions/LogService.ClearLog"
             print(clear_dump_uri)
             uri = self.dut().uri_builder.format_uri(redfish_str="{GPUMC}" + "{}".format(clear_dump_uri), component_type="GPU")
-            self.dut().run_redfish_command(uri=uri, mode="POST")
-        self.write_test_info("{}".format(result))
+            response = self.dut().run_redfish_command(uri=uri, mode="POST")
+            if response is None or response.status != 200:
+                result = False
+        self.write_test_info("Clearing Log Dump Action Successful: {}".format(result))
         return result
     
     def trigger_self_test_dump_collection(self):
@@ -182,6 +231,48 @@ class HealthCheckIfc(FunctionalIfc):
                     self.test_run().add_log(LogSeverity.ERROR, msg)
 
         return SelfTestReport_Status
+    
+    def ctam_get_all_logdump_uris(self, resource_collection_list=["Systems", "Managers", "Chassis"]):
+        """
+        :Description:	                    Look for Dump URIs under all LogServices URIs of specific resourcse collection.
+        
+        :param resource_collection_list:    list of resource collectionsto check. Default is ["Systems", "Managers", "Chassis"]
+        :type resource_collection_list:     list
+
+        :return:                            list of LogServices Dump uri
+        :rtype:                             list
+        """
+        self.ctam_get_all_logservice_uris(resource_collection_list)
+        for resource in resource_collection_list:
+            dumplog_uri_list = []
+            for uri in self.logservice_uri_dict[resource]:
+                self.ctam_redfish_uri_hunt(uri, "Dump", dumplog_uri_list)
+            self.dumplog_uri_dict[resource] = dumplog_uri_list
+            self.dumplog_uri_list.extend(dumplog_uri_list)
+        self.write_test_info("Dump URI list: {}".format(self.dumplog_uri_list))
+        return self.dumplog_uri_list
+    
+    def ctam_verify_logdump_presence(self, resource_collection_list=["Systems", "Managers", "Chassis"]):
+        """
+        :Description:	                    Verify if the Dump URI is present under all LogServices URI of specified resourcse collection.
+        
+        :param resource_collection_list:    list of resource collectionsto check. Default is ["Systems", "Managers", "Chassis"]
+        :type resource_collection_list:     list
+
+        :return:                            result if the verification passed/failed
+        :rtype:                             bool
+        """
+        result = True
+        if self.dumplog_uri_dict == {}:
+            self.test_run().add_log(LogSeverity.ERROR, f"LogServices Dump URI List is empty. Nothing to verify!")
+            result = False
+        else:
+            for resource_collection in resource_collection_list:
+                if resource_collection not in self.dumplog_uri_dict or self.dumplog_uri_dict[resource_collection] == []:
+                    self.test_run().add_log(LogSeverity.ERROR, f"Checking existing URI list - Dump is not found in {resource_collection}")
+                    result = False
+        return result
+            
     
     def ctam_get_logdump_uris(self):
         if self.logservice_uri_list == []:

--- a/ctam/test_runner.py
+++ b/ctam/test_runner.py
@@ -571,6 +571,21 @@ class LoggingWriter(Writer):
                 return
 
         self.logger.info(buffer)
+        
+    def log(self, msg: str):
+        """
+        Called from the OCP framework for logging messages. This method is a wrapper
+        of the "write" method to add timestamp to a message.
+
+        :param msg: Message to be logged
+        :type msg: str
+        """
+        json_msg = {
+                    "TimeStamp": datetime.now().strftime("%m-%d-%YT%H:%M:%S"),
+                    "Message": msg
+        }
+
+        self.write(json.dumps(json_msg))
 
 
 class JsonFormatter(logging.Formatter):

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_logservice_dump_uri_list_read.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_logservice_dump_uri_list_read.py
@@ -67,19 +67,28 @@ class CTAMTestLogServiceDumpURIListRead(TestCase):
         result = True
         step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
         with step1.scope():
-            if (dump_uri := self.group.health_check_ifc.ctam_get_logdump_uris()) == []:
+            if (dump_uri := self.group.health_check_ifc.ctam_get_all_logdump_uris()) == []:
                 step1.add_log(
                     LogSeverity.FATAL,
-                    f"{self.test_id} : Test case Failed - LogService Dump list is empty",
+                    f"{self.test_id} : Redfish LogService Dump URI list Read Failed - Dump list is empty",
                 )
                 result = False
             else:
                 pprint(dump_uri)
                 step1.add_log(
                     LogSeverity.INFO,
-                    f"{self.test_id} : Test case Passed.",
+                    f"{self.test_id} : Redfish LogService Dump URI list Read Completed.",
                 )
-                result = True
+                
+        
+        if result:
+            step2 = self.test_run().add_step(f"{self.__class__.__name__} run(), step2")  # type: ignore
+            with step2.scope():
+                if self.group.health_check_ifc.ctam_verify_logdump_presence():
+                    step2.add_log(LogSeverity.INFO, f"{self.test_id} : Redfish LogService Dump URI list Verification - Passed")
+                else:
+                    step2.add_log(LogSeverity.ERROR,f"{self.test_id} : Redfish LogService Dump URI list Verification - Failed")
+                    result = False
 
         # ensure setting of self.result and self.score prior to calling super().run()
         self.result = TestResult.PASS if result else TestResult.FAIL

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_logservice_uri_list_read.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_logservice_uri_list_read.py
@@ -65,22 +65,30 @@ class CTAMTestLogServicesURIListRead(TestCase):
         """
         actual test verification
         """
-        result = False
+        result = True
         step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
         with step1.scope():
-            if (logservice := self.group.health_check_ifc.ctam_get_logservice_uris()) == []:
+            if (logservice := self.group.health_check_ifc.ctam_get_all_logservice_uris()) == []:
                 step1.add_log(
                     LogSeverity.FATAL,
-                    f"{self.test_id} : Test case Failed - LogService list is empty",
+                    f"{self.test_id} : Redfish LogService URI list Read Failed - LogService list is empty",
                 )
                 result = False
             else:
                 pprint(logservice)
                 step1.add_log(
                     LogSeverity.INFO,
-                    f"{self.test_id} : Test case Passed.",
+                    f"{self.test_id} : Redfish LogService URI list Read Completed",
                 )
-                result = True
+   
+        if result:
+            step2 = self.test_run().add_step(f"{self.__class__.__name__} run(), step2")  # type: ignore
+            with step2.scope():
+                if self.group.health_check_ifc.ctam_verify_logservice_presence():
+                    step2.add_log(LogSeverity.INFO, f"{self.test_id} : Redfish LogService URI list Verification - Passed")
+                else:
+                    step2.add_log(LogSeverity.ERROR,f"{self.test_id} : Redfish LogService URI list Verification - Failed")
+                    result = False
 
         # ensure setting of self.result and self.score prior to calling super().run()
         self.result = TestResult.PASS if result else TestResult.FAIL

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_event_service.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_event_service.py
@@ -66,18 +66,19 @@ class CTAMTestRedfishEventService(TestCase):
         """
         actual test verification
         """
+        result = True
+        
         step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
         with step1.scope():
-            self.group.health_check_ifc.ctam_getes()
-
-        step2 = self.test_run().add_step(f"{self.__class__.__name__} step2")  # type: ignore
-        with step2.scope():
-            debug_mode = self.dut().is_debug_mode()
-            msg = f"Debug mode is :{debug_mode} in {self.__class__.__name__}"
-            self.test_run().add_log(severity=LogSeverity.DEBUG, message=msg)  # type: ignore
+            JSONData = self.group.health_check_ifc.ctam_getes()
+            if JSONData is None or "error" in JSONData:
+                step1.add_log(LogSeverity.ERROR, f"{self.test_id} : Redfish Event Service Check - Failed")
+                result = False
+            else:
+                step1.add_log(LogSeverity.INFO, f"{self.test_id} : Redfish Event Service Check - Completed")
 
         # ensure setting of self.result and self.score prior to calling super().run()
-        self.result = TestResult.PASS
+        self.result = TestResult.PASS if result else TestResult.FAIL
         if self.result == TestResult.PASS:
             self.score = self.score_weight
 

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_firmware_inventory_collection.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_firmware_inventory_collection.py
@@ -66,18 +66,19 @@ class CTAMTestRedfishFirmwareInventoryCollection(TestCase):
         """
         actual test verification
         """
+        result = True
+        
         step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
         with step1.scope():
-            self.group.health_check_ifc.ctam_getfi()
-
-        step2 = self.test_run().add_step(f"{self.__class__.__name__} step2")  # type: ignore
-        with step2.scope():
-            debug_mode = self.dut().is_debug_mode()
-            msg = f"Debug mode is :{debug_mode} in {self.__class__.__name__}"
-            self.test_run().add_log(severity=LogSeverity.DEBUG, message=msg)  # type: ignore
+            JSONData = self.group.health_check_ifc.ctam_getfi()
+            if JSONData is None or "error" in JSONData:
+                step1.add_log(LogSeverity.ERROR, f"{self.test_id} : Redfish FW Inventory Collection Check - Failed")
+                result = False
+            else:
+                step1.add_log(LogSeverity.INFO, f"{self.test_id} : Redfish FW Inventory Collection Check - Completed")
 
         # ensure setting of self.result and self.score prior to calling super().run()
-        self.result = TestResult.PASS
+        self.result = TestResult.PASS if result else TestResult.FAIL
         if self.result == TestResult.PASS:
             self.score = self.score_weight
 

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_software_inventory_collection.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_software_inventory_collection.py
@@ -67,18 +67,19 @@ class CTAMTestRedfishSoftwareInventoryCollection(TestCase):
         """
         actual test verification
         """
+        result = True
+        
         step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
         with step1.scope():
-            self.group.health_check_ifc.ctam_getsi()
-
-        step2 = self.test_run().add_step(f"{self.__class__.__name__} step2")  # type: ignore
-        with step2.scope():
-            debug_mode = self.dut().is_debug_mode()
-            msg = f"Debug mode is :{debug_mode} in {self.__class__.__name__}"
-            self.test_run().add_log(severity=LogSeverity.DEBUG, message=msg)  # type: ignore
+            JSONData = self.group.health_check_ifc.ctam_getsi()
+            if JSONData is None or "error" in JSONData:
+                step1.add_log(LogSeverity.ERROR, f"{self.test_id} : Redfish SW Inventory Collection Check - Failed")
+                result = False
+            else:
+                step1.add_log(LogSeverity.INFO, f"{self.test_id} : Redfish SW Inventory Collection Check - Completed")
 
         # ensure setting of self.result and self.score prior to calling super().run()
-        self.result = TestResult.PASS
+        self.result = TestResult.PASS if result else TestResult.FAIL
         if self.result == TestResult.PASS:
             self.score = self.score_weight
 

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_task_service.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_task_service.py
@@ -66,18 +66,19 @@ class CTAMTestRedfishTaskService(TestCase):
         """
         actual test verification
         """
+        result = True
+        
         step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
         with step1.scope():
-            self.group.health_check_ifc.ctam_gettsks()
-
-        step2 = self.test_run().add_step(f"{self.__class__.__name__} step2")  # type: ignore
-        with step2.scope():
-            debug_mode = self.dut().is_debug_mode()
-            msg = f"Debug mode is :{debug_mode} in {self.__class__.__name__}"
-            self.test_run().add_log(severity=LogSeverity.DEBUG, message=msg)  # type: ignore
+            JSONData = self.group.health_check_ifc.ctam_gettsks()
+            if JSONData is None or "error" in JSONData:
+                step1.add_log(LogSeverity.ERROR, f"{self.test_id} : Redfish Task Service Check - Failed")
+                result = False
+            else:
+                step1.add_log(LogSeverity.INFO, f"{self.test_id} : Redfish Task Service Check - Completed")
 
         # ensure setting of self.result and self.score prior to calling super().run()
-        self.result = TestResult.PASS
+        self.result = TestResult.PASS if result else TestResult.FAIL
         if self.result == TestResult.PASS:
             self.score = self.score_weight
 

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_telemetry_service.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_telemetry_service.py
@@ -66,18 +66,19 @@ class CTAMTestRedfishTelemetryService(TestCase):
         """
         actual test verification
         """
+        result = True
+        
         step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
         with step1.scope():
-            self.group.health_check_ifc.ctam_getts()
-
-        step2 = self.test_run().add_step(f"{self.__class__.__name__} step2")  # type: ignore
-        with step2.scope():
-            debug_mode = self.dut().is_debug_mode()
-            msg = f"Debug mode is :{debug_mode} in {self.__class__.__name__}"
-            self.test_run().add_log(severity=LogSeverity.DEBUG, message=msg)  # type: ignore
+            JSONData = self.group.health_check_ifc.ctam_getts()
+            if JSONData is None or "error" in JSONData:
+                step1.add_log(LogSeverity.ERROR, f"{self.test_id} : Redfish Task Service Check - Failed")
+                result = False
+            else:
+                step1.add_log(LogSeverity.INFO, f"{self.test_id} : Redfish Task Service Check - Completed")
 
         # ensure setting of self.result and self.score prior to calling super().run()
-        self.result = TestResult.PASS
+        self.result = TestResult.PASS if result else TestResult.FAIL
         if self.result == TestResult.PASS:
             self.score = self.score_weight
 

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_update_service.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_update_service.py
@@ -66,18 +66,19 @@ class CTAMTestRedfishUpdateService(TestCase):
         """
         actual test verification
         """
+        result = True
+        
         step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
         with step1.scope():
-            self.group.health_check_ifc.ctam_getus()
-
-        step2 = self.test_run().add_step(f"{self.__class__.__name__} step2")  # type: ignore
-        with step2.scope():
-            debug_mode = self.dut().is_debug_mode()
-            msg = f"Debug mode is :{debug_mode} in {self.__class__.__name__}"
-            self.test_run().add_log(severity=LogSeverity.DEBUG, message=msg)  # type: ignore
+            JSONData = self.group.health_check_ifc.ctam_getus()
+            if JSONData is None or "error" in JSONData:
+                step1.add_log(LogSeverity.ERROR, f"{self.test_id} : Redfish Update Service Check - Failed")
+                result = False
+            else:
+                step1.add_log(LogSeverity.INFO, f"{self.test_id} : Redfish Update Service Check - Completed")
 
         # ensure setting of self.result and self.score prior to calling super().run()
-        self.result = TestResult.PASS
+        self.result = TestResult.PASS if result else TestResult.FAIL
         if self.result == TestResult.PASS:
             self.score = self.score_weight
 

--- a/ctam/utils/fwpkg_utils.py
+++ b/ctam/utils/fwpkg_utils.py
@@ -99,6 +99,36 @@ class PLDMFwpkg:
             corrupted_package_path = None
             
         return corrupted_package_path
+    
+    @staticmethod
+    def make_large_package(golden_fwpkg_path, max_bundle_size):
+        """
+        :Description:                       Create a package that is larger than the allowed max size.
+
+        :param str golden_fwpkg_path:	    Path to golden firmware package
+        :param int max_bundle_size:         Maximum allowed size of the PLDM bundle.
+
+        :returns:                           Path to corrupted package. None if corruption fails. 
+        :rtype:                             str
+        """
+        # Make a copy of the golden fwpkg
+        corrupted_package =  os.path.join(os.path.dirname(golden_fwpkg_path), "corrupted-pkg.fwpkg")
+        corrupted_package_path = shutil.copy(golden_fwpkg_path, corrupted_package)
+        
+        with open(golden_fwpkg_path, 'rb') as infile:
+            golden_fwpkg_content = infile.read()
+        golden_fwpkg_size = os.path.getsize(golden_fwpkg_path)
+        try:
+            with open(corrupted_package_path, 'a+b') as large_fwpkg:
+                for i in range(max_bundle_size//golden_fwpkg_size+1):
+                    large_fwpkg.write(golden_fwpkg_content)
+        except Exception as e:
+            print(f"Error in creating a large package: {e}")
+            # delete the package
+            os.remove(corrupted_package_path)
+            corrupted_package_path = None
+
+        return corrupted_package_path
 
 class FwpkgSignature:
     """

--- a/json_spec/input/dut_info.json
+++ b/json_spec/input/dut_info.json
@@ -17,7 +17,17 @@
     "SshTunnel": {
       "description": "Indicates if the user wants to communicate through SSH tunnel",
       "type": "bool",
-      "value": ""
+      "value": false
+    },
+    "AuthenticationRequired": {
+      "description": "Indicates if REST API authentication is required by the Redfish service",
+      "type": "bool",
+      "value": false
+    },
+    "UnstructuredHttpPush": {
+      "description": "Indicates if firmware update service supports Unstructured HTTP push update operation (vendor-specific)",
+      "type": "bool",
+      "value": false
     },
     "DefaultPrefix": {
       "description": "Default preix for connecting to redfish",

--- a/json_spec/input/dut_info.json
+++ b/json_spec/input/dut_info.json
@@ -75,12 +75,12 @@
       "value": ""
     },
     "PowerOffWaitTime": {
-      "description": "Off delay needed during FW Activation",
+      "description": "Off delay needed (in seconds) during FW Activation",
       "type": "int",
       "value": 60
     },
     "PowerOnWaitTime": {
-      "description": "Wait time during FW Activation post reset cycle",
+      "description": "Wait time (in seconds) during FW Activation post reset cycle",
       "type": "int",
       "value": 300
     },


### PR DESCRIPTION
**Major changes:**
- Updated all the health check tests result assignment logic. Most test results are now assigned based on presence of "error" in the API response.
- Updated the logic of LogServices and Dump URI reading. An additional verification is done to make sure all the resources (Chassis, Manager, Systems) have LogServices and Dump in it.
- Fixed bugs in H96 (Dump Clear Log): Fixed the API call by using correct API and using POST call. Also added a check to make sure the API call to clear log was successful.
- Added additional check in H6 to ensure the "expand" worked.
- Minor change in dut_info.json to clarify unit of time (seconds).
- Added creating large package functionality (WIP)
- Added timeout in Redfish API calls
- Added Redfish authentication login
- Not check empty SoftwareIDs and not checking version for component does not present in PLDM bundle (WIP)
- Added Unstructured Push Update option
- Fixed port forwarding issue with port already in use not raising error
- Using logging method

**Test result:**
Here is the result from running all the health check test groups. Note that:
- H50 is failing because of an internal service issue in the current test system. It passes in other systems.
- H97 test requirement/logic needs to be discussed in OCP forum. The requirement of "Dump" in LogServices and LogService ID (e.g. Dump, EventLog, Journal etc.) need to be standardized. This requirement affects H96 (clear log) testcase too.

TestID | TestName | TestScore | TestResult
-- | -- | -- | --
H5 | CTAM Test Redfish Firmware Inventory Collection | 10 | PASS
H6 | CTAM Test Redfish Firmware Inventory Expanded Collection | 10 | PASS
H8 | CTAM Test Redfish Event Service | 10 | PASS
H4 | CTAM Test Redfish Update Service | 10 | PASS
H7 | CTAM Test Redfish Telemetry Service | 10 | PASS
H99 | CTAM Test LogServices URI List Read | 10 | PASS
H10 | CTAM Test Redfish Task Service | 10 | PASS
H50 | CTAM Test Verify Self-Test Report | 0 | FAIL
H9 | CTAM Test Redfish Software Inventory Collection | 10 | PASS
H97 | CTAM Test LogService Dump URI List Read | 0 | FAIL
H100 | CTAM Test AC Cycles In Loop | 10 | PASS
H96 | CTAM Test LogService Dump Clear | 10 | PASS
  | Compliance Score | Total Test Score | Grade
Total Score | 100 | 120 | 83.3%

