### PR TITLE
Misc. changes: Summary Report + F23 fwpkg Corruption + Removed shell=True

### DIFF
--- a/ctam/ctam.py
+++ b/ctam/ctam.py
@@ -182,6 +182,7 @@ def main():
       
 if __name__ == "__main__":
     status_code, log_directory, exit_string = main() 
-    print("Test exited with status code: {} - {}".format("FAIL" if status_code else "PASS", exit_string))
-    print(f"Log Directory: {log_directory}")
+    print("\nTest exited with status code*: {} - {}".format("FAIL" if status_code else "PASS", exit_string))
+    print(f"Log Directory: {log_directory}") 
+    print("\n*Note: Return/Status Codes - PASS(0): All tests passed, FAIL(1): Execution/runtime failure or test failure\n")
     exit(status_code)

--- a/ctam/interfaces/comptool_dut.py
+++ b/ctam/interfaces/comptool_dut.py
@@ -260,7 +260,7 @@ class CompToolDut(Dut):
         """
         PortList = [18888, 18889]
         for port in PortList:
-            ssh_cmd = "sshpass -p {ssh_password} ssh -fNT -L {binded_port}:{amc_ip}:80 {ssh_username}@{bmc_ip} -p 22".format(
+            ssh_cmd = "sshpass -p {ssh_password} ssh -4 -o StrictHostKeyChecking=no -fNT -L {binded_port}:{amc_ip}:80 {ssh_username}@{bmc_ip} -p 22".format(
                     ssh_password = self.__user_pass,
                     binded_port = port,
                     ssh_username = self.__user_name,

--- a/ctam/interfaces/functional_ifc.py
+++ b/ctam/interfaces/functional_ifc.py
@@ -128,7 +128,7 @@ class FunctionalIfc:
                     self.dut().package_config.get("GPU_FW_IMAGE", {}).get("Path", ""),
                     self.dut().package_config.get("GPU_FW_IMAGE", {}).get("Package", ""),
                 )
-                json_fw_file_payload = FwpkgSignature.clear_signature_in_pkg(golden_fwpkg_path)
+                json_fw_file_payload = FwpkgSignature.invalidate_signature_in_pkg(golden_fwpkg_path)
             
         elif image_type == "invalid_pkg_uuid":
             golden_fwpkg_path = os.path.join(
@@ -772,6 +772,7 @@ class FunctionalIfc:
         ctam_getes_uri = self.dut().uri_builder.format_uri(redfish_str="{BaseURI}/EventService/Subscriptions", component_type="GPU")
         subscriptionList = self.ctam_getes("Subscriptions")
         self.test_run().add_log(LogSeverity.INFO, "subscriptionList is {}\n".format(subscriptionList))
+        # FIXME: Handle when subscriptionList is empty
         ctam_getes_uri = ctam_getes_uri + "/" + subscriptionList[-1]
         response = self.dut().run_redfish_command(uri=ctam_getes_uri, mode="DELETE")
         status = response.status

--- a/ctam/interfaces/fw_update_ifc.py
+++ b/ctam/interfaces/fw_update_ifc.py
@@ -247,7 +247,7 @@ class FWUpdateIfc(FunctionalIfc):
         else:
             if image_type == "large":
                 GPULargeFWMessage = "{GPULargeFWMessage}".format(**self.dut().redfish_uri_config.get("GPU"))
-                if GPULargeFWMessage in JSONData["error"]:
+                if GPULargeFWMessage in JSONData["error"] or GPULargeFWMessage in JSONData["error"].get("message", {}) : # FIXME: Temp fix to make it work in both MSFT and Nvidia systems
                     StageFWOOB_Status = True
                 else:
                     StageFWOOB_Status = False

--- a/ctam/interfaces/fw_update_ifc.py
+++ b/ctam/interfaces/fw_update_ifc.py
@@ -294,7 +294,7 @@ class FWUpdateIfc(FunctionalIfc):
             if negative_case:
                 # FW version should be same as from pre-update
                 ExpectedVersion = self.PreInstallVersionDetails[element["Id"]]
-                msg = "negative test case, expected version = {}".format(
+                msg = "FW should not be updated, expected version = {}".format(
                     ExpectedVersion
                 )
                 self.test_run().add_log(LogSeverity.DEBUG, msg)

--- a/ctam/test_runner.py
+++ b/ctam/test_runner.py
@@ -555,6 +555,7 @@ class TestRunner:
 
         except (NotImplementedError, Exception) as e:
             exception_details = traceback.format_exc()
+            # FIXME: Throws error if the exception happens before setting active_run (e.g. in comptool_dut init)
             self.active_run.add_log(
                 severity=LogSeverity.FATAL, message=exception_details
             )

--- a/ctam/tests/test_case.py
+++ b/ctam/tests/test_case.py
@@ -34,6 +34,7 @@ class TestCase(ABC):
     _dut: Optional[CompToolDut]  # dut object
     total_compliance_score = 0  # accumulative
     max_compliance_score = 0
+    total_execution_time = 0 # seconds
 
     @staticmethod
     def SetUpAssociations(testrun: tv.TestRun, dut: CompToolDut):
@@ -49,6 +50,7 @@ class TestCase(ABC):
         TestCase._dut = dut
         TestCase.total_compliance_score = 0
         TestCase.max_compliance_score = 0
+        TestCase.total_execution_time = 0
 
     def __init__(self):
         """

--- a/ctam/utils/fwpkg_utils.py
+++ b/ctam/utils/fwpkg_utils.py
@@ -62,7 +62,7 @@ class PLDMFwpkg:
         
         pldm_parser = PLDMUnpack(corrupted_package_path)
         if result := pldm_parser.parse_pldm_package():
-            result = pldm_parser.corrupt_component_metadata_in_pkg(corrupted_package_path, component_id, metadata_size)
+            result = pldm_parser.corrupt_component_metadata_in_pkg(component_id, metadata_size)
             
         if not result:
             print(f"Error in corrupting the package.")
@@ -159,7 +159,7 @@ class FwpkgSignature:
     """
     Methods related to PLDM fwpkg signature
     """
-    NUM_BYTES_FROM_END = 1024
+    PKG_SIGNATURE_STRUCT_BYTES = 1024
     HeaderV2 = 2
     HeaderV3 = 3
     
@@ -175,7 +175,7 @@ class FwpkgSignature:
         """
         try:
             with open(package_path, 'rb') as infile:
-                infile.seek(-FwpkgSignature.NUM_BYTES_FROM_END, os.SEEK_END)
+                infile.seek(-FwpkgSignature.PKG_SIGNATURE_STRUCT_BYTES, os.SEEK_END)
                 infile.seek(4, 1)
                 major_version = infile.read(1)
                 minor_version = infile.read(1)
@@ -198,7 +198,7 @@ class FwpkgSignature:
         """
         try:
             with open(fwpkg_path, 'r+b') as file:
-                file.seek(-FwpkgSignature.NUM_BYTES_FROM_END + skip_byte, os.SEEK_END)
+                file.seek(-FwpkgSignature.PKG_SIGNATURE_STRUCT_BYTES + skip_byte, os.SEEK_END)
                 file.write(bytes([value]))
             return True
         except Exception as e:
@@ -251,7 +251,7 @@ class FwpkgSignature:
         
         try:
             with open(corrupted_package_path, 'r+b') as file:
-                file.seek(-FwpkgSignature.NUM_BYTES_FROM_END, os.SEEK_END)
+                file.seek(-FwpkgSignature.PKG_SIGNATURE_STRUCT_BYTES, os.SEEK_END)
                 file.write(bytearray(4)) # 4 bytes long Magic
         except Exception as e:
             print(f"Error in corrupting the package: {e}")
@@ -276,8 +276,8 @@ class FwpkgSignature:
         corrupted_package_path = shutil.copy(golden_fwpkg_path, corrupted_package)
         try:
             with open(corrupted_package_path, 'r+b') as file:
-                file.seek(-FwpkgSignature.NUM_BYTES_FROM_END, os.SEEK_END)
-                file.write(bytearray(FwpkgSignature.NUM_BYTES_FROM_END))
+                file.seek(-FwpkgSignature.PKG_SIGNATURE_STRUCT_BYTES, os.SEEK_END)
+                file.write(bytearray(FwpkgSignature.PKG_SIGNATURE_STRUCT_BYTES))
         except Exception as e:
             print(f"Error in corrupting the package: {e}")
             # delete the package


### PR DESCRIPTION
- Added test execution time and number of testcases in summart report
- Added fwpkg modification for F23 testcase
- Removed shell=True from power cycling command for security issue.
- Enhanced the cmd to create shh-tunneling to disable StrictHostKeyChecking and force IPv4 usage.
- Resolved minor bug (typo) in fwpkg_util
- ctam_managers_ethernet_interfaces_gateway_write using what it just read for the patch
- Added checking of "message" field in "error" for large FWUPD test

Test Result:
![image](https://github.com/opencomputeproject/ocp-diag-ctam/assets/139162087/6056e2e5-e3cb-4a6c-bd66-5a50edb8ba48)
