### PR TITLE
F55, F56 tackling integrity check + new testcase F90 for unsigned PLDM bundle + F89 single device ping-pong bugfix 

### DIFF
--- a/ctam/interfaces/comptool_dut.py
+++ b/ctam/interfaces/comptool_dut.py
@@ -14,6 +14,7 @@ import netrc
 import subprocess
 import platform
 import json
+import time
 from datetime import datetime
 
 # import pandas as pd
@@ -122,7 +123,7 @@ class CompToolDut(Dut):
 
     def run_redfish_command(self, uri, mode="GET", body=None, headers=None, timeout=None):
         """
-        This method is for running redfish commands according to mode and log the ouput into
+        This method is for running redfish commands according to mode and log the output into
         a formatted log file and return the response
         
         :param uri: uri for redfish connection
@@ -138,6 +139,7 @@ class CompToolDut(Dut):
         :rtype: response object or None in case of failure
         """
         try:
+            start_time = time.time()
             response = None
             msg = {
                     "TimeStamp": datetime.now().strftime("%m-%d-%YT%H:%M:%S"),
@@ -163,7 +165,17 @@ class CompToolDut(Dut):
             elif mode == "DELETE":
                 msg.update({"Method":"DELETE",})
                 response = self.redfish_ifc.delete(**kwargs) # path=uri, headers=headers   
-                
+            
+            end_time = time.time()
+            time_difference_seconds = end_time - start_time
+            time_difference = datetime.utcfromtimestamp(time_difference_seconds) - datetime.utcfromtimestamp(0)
+            hours, remainder = divmod(time_difference.seconds, 3600)
+            minutes, seconds = divmod(remainder, 60)
+            milliseconds = int(time_difference.microseconds / 1000)
+            formatted_time = "{:02d}H:{:02d}M:{:02d}S:{:03d}MS".format(hours, minutes, seconds, milliseconds)
+            
+            msg.update({"ResponseTime": "{}".format(formatted_time)})
+
             if response.status in range (200,204) and response.text: # FIXME: Add error handling in case the request fails
                 msg.update({
                     "ResponseCode": response.status,
@@ -184,6 +196,7 @@ class CompToolDut(Dut):
                     "ResponseCode": f"Unexpected status: {response.status}",
                     "Response": response.text,
                     })
+            # msg.update({"TimeTaken": time_taken})
         except Exception as e:
             msg.update({
             "ResponseCode": None,

--- a/ctam/interfaces/comptool_dut.py
+++ b/ctam/interfaces/comptool_dut.py
@@ -179,7 +179,7 @@ class CompToolDut(Dut):
             if response.status in range (200,204) and response.text: # FIXME: Add error handling in case the request fails
                 msg.update({
                     "ResponseCode": response.status,
-                    "Response":response.dict, # FIXED: Throws error in some cases when response.dict is used and the response body is empty
+                    "Response":response.dict, # FIXME: self-test report cannot be converted to dict # FIXED: Throws error in some cases when response.dict is used and the response body is empty
                     }) 
             elif response.status in range (200,204):
                 msg.update({

--- a/ctam/interfaces/comptool_dut.py
+++ b/ctam/interfaces/comptool_dut.py
@@ -14,7 +14,6 @@ import netrc
 import subprocess
 import platform
 import json
-import time
 from datetime import datetime
 
 # import pandas as pd
@@ -123,7 +122,7 @@ class CompToolDut(Dut):
 
     def run_redfish_command(self, uri, mode="GET", body=None, headers=None, timeout=None):
         """
-        This method is for running redfish commands according to mode and log the output into
+        This method is for running redfish commands according to mode and log the ouput into
         a formatted log file and return the response
         
         :param uri: uri for redfish connection
@@ -139,7 +138,6 @@ class CompToolDut(Dut):
         :rtype: response object or None in case of failure
         """
         try:
-            start_time = time.time()
             response = None
             msg = {
                     "TimeStamp": datetime.now().strftime("%m-%d-%YT%H:%M:%S"),
@@ -165,17 +163,7 @@ class CompToolDut(Dut):
             elif mode == "DELETE":
                 msg.update({"Method":"DELETE",})
                 response = self.redfish_ifc.delete(**kwargs) # path=uri, headers=headers   
-            
-            end_time = time.time()
-            time_difference_seconds = end_time - start_time
-            time_difference = datetime.utcfromtimestamp(time_difference_seconds) - datetime.utcfromtimestamp(0)
-            hours, remainder = divmod(time_difference.seconds, 3600)
-            minutes, seconds = divmod(remainder, 60)
-            milliseconds = int(time_difference.microseconds / 1000)
-            formatted_time = "{:02d}H:{:02d}M:{:02d}S:{:03d}MS".format(hours, minutes, seconds, milliseconds)
-            
-            msg.update({"ResponseTime": "{}".format(formatted_time)})
-
+                
             if response.status in range (200,204) and response.text: # FIXME: Add error handling in case the request fails
                 msg.update({
                     "ResponseCode": response.status,
@@ -196,7 +184,6 @@ class CompToolDut(Dut):
                     "ResponseCode": f"Unexpected status: {response.status}",
                     "Response": response.text,
                     })
-            # msg.update({"TimeTaken": time_taken})
         except Exception as e:
             msg.update({
             "ResponseCode": None,

--- a/ctam/interfaces/functional_ifc.py
+++ b/ctam/interfaces/functional_ifc.py
@@ -161,17 +161,28 @@ class FunctionalIfc:
             metadata_size = self.dut().package_config.get("GPU_FW_IMAGE_CORRUPT_COMPONENT", {}).get("MetadataSizeBytes", 4096)
             json_fw_file_payload = PLDMFwpkg.clear_component_metadata_in_pkg(golden_fwpkg_path, corrupted_component_id, metadata_size)
         
-        elif image_type == "empty_component":
-            if corrupted_component_id is None:
-                corrupted_component_id = self.ctam_get_component_to_be_corrupted()
-            msg = f"Corrupted component ID: {corrupted_component_id}"
-            self.test_run().add_log(LogSeverity.DEBUG, msg)
-            golden_fwpkg_path = os.path.join(
-                self.dut().cwd,
-                self.dut().package_config.get("GPU_FW_IMAGE", {}).get("Path", ""),
-                self.dut().package_config.get("GPU_FW_IMAGE", {}).get("Package", ""),
-            )
-            json_fw_file_payload = PLDMFwpkg.clear_component_image_in_pkg(golden_fwpkg_path, corrupted_component_id)
+        elif image_type == "corrupt_component":
+            if self.dut().package_config.get("GPU_FW_IMAGE_CORRUPT_COMPONENT", {}).get("Package", "") != "":
+                json_fw_file_payload = os.path.join(
+                    self.dut().cwd,
+                    self.dut()
+                    .package_config.get("GPU_FW_IMAGE_CORRUPT_COMPONENT", {})
+                    .get("Path", ""),
+                    self.dut()
+                    .package_config.get("GPU_FW_IMAGE_CORRUPT_COMPONENT", {})
+                    .get("Package", ""),
+                )
+            else:
+                if corrupted_component_id is None:
+                    corrupted_component_id = self.ctam_get_component_to_be_corrupted()
+                msg = f"Corrupted component ID: {corrupted_component_id}"
+                self.test_run().add_log(LogSeverity.DEBUG, msg)
+                golden_fwpkg_path = os.path.join(
+                    self.dut().cwd,
+                    self.dut().package_config.get("GPU_FW_IMAGE", {}).get("Path", ""),
+                    self.dut().package_config.get("GPU_FW_IMAGE", {}).get("Package", ""),
+                )
+                json_fw_file_payload = PLDMFwpkg.clear_component_image_in_pkg(golden_fwpkg_path, corrupted_component_id)
         
         elif image_type == "backup":
             json_fw_file_payload = os.path.join(
@@ -192,15 +203,28 @@ class FunctionalIfc:
                 .get("Package", ""),
             )
 
-        elif image_type == "unsigned":
-            if self.dut().package_config.get("GPU_FW_IMAGE_UNSIGNED", {}).get("Package", "") != "":
+        elif image_type == "unsigned_component_image":
+            # As of now, there is no suitable way to update the component's signature on-the-fly.
+            # So vendor needs to provide a bundle with an unsigned component image
+            json_fw_file_payload = os.path.join(
+                self.dut().cwd,
+                self.dut()
+                .package_config.get("GPU_FW_IMAGE_UNSIGNED_COMPONENT", {})
+                .get("Path", ""),
+                self.dut()
+                .package_config.get("GPU_FW_IMAGE_UNSIGNED_COMPONENT", {})
+                .get("Package", ""),
+            )
+                
+        elif image_type == "unsigned_bundle":
+            if self.dut().package_config.get("GPU_FW_IMAGE_UNSIGNED_BUNDLE", {}).get("Package", "") != "":
                 json_fw_file_payload = os.path.join(
                     self.dut().cwd,
                     self.dut()
-                    .package_config.get("GPU_FW_IMAGE_UNSIGNED", {})
+                    .package_config.get("GPU_FW_IMAGE_UNSIGNED_BUNDLE", {})
                     .get("Path", ""),
                     self.dut()
-                    .package_config.get("GPU_FW_IMAGE_UNSIGNED", {})
+                    .package_config.get("GPU_FW_IMAGE_UNSIGNED_BUNDLE", {})
                     .get("Package", ""),
                 )
             else:
@@ -251,7 +275,7 @@ class FunctionalIfc:
         :rtype:                 string
         """
         pldm_json_file = ""
-        if image_type == "default" or image_type == "corrupt_component":
+        if image_type == "default":
             pldm_json_file = os.path.join(
                 self.dut().cwd,
                 self.dut().package_config.get("GPU_FW_IMAGE", {}).get("Path", ""),
@@ -274,6 +298,14 @@ class FunctionalIfc:
                 self.dut().package_config.get("GPU_FW_IMAGE_OLD", {}).get("Path", ""),
                 self.dut().package_config.get("GPU_FW_IMAGE_OLD", {}).get("JSON", ""),
             )
+            
+        elif image_type == "corrupt_component":
+            pldm_json_file = os.path.join(
+                self.dut().cwd,
+                self.dut().package_config.get("GPU_FW_IMAGE_CORRUPT_COMPONENT", {}).get("Path", ""),
+                self.dut().package_config.get("GPU_FW_IMAGE_CORRUPT_COMPONENT", {}).get("JSON", ""),
+            )
+            
         return pldm_json_file
 
     def ctam_getfi(self, expanded=0):

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_activation_with_failed_component.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_activation_with_failed_component.py
@@ -9,6 +9,8 @@ LICENSE file in the root directory of this source tree.
 :Score Weight:	10
 
 :Description:	Firmware Update Stack Robustness Test. If one component copying (staging) fails, verify activation is handled correctly.
+                Vendor needs to provide a fwpkg where a component image is corrupted, and all other component images are good (i.e. it will not fail the update).
+                
 :Usage 1:		python ctam.py -w ..\workspace -t F56
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Full Device Update Activation With Failed Component"
 
@@ -47,6 +49,7 @@ class CTAMTestFullDeviceUpdateActivationWithFailedComponent(TestCase):
         """
         super().__init__()
         self.group = group
+        self.corrupted_component_id = None
 
     def setup(self):
         """
@@ -66,29 +69,39 @@ class CTAMTestFullDeviceUpdateActivationWithFailedComponent(TestCase):
         """
         result = True
         
-        corrupted_component_id = self.group.fw_update_ifc.ctam_get_component_to_be_corrupted()
-
-        step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
-        with step1.scope():
-            if not self.group.fw_update_ifc.ctam_fw_update_precheck():
-                step1.add_log(LogSeverity.INFO, f"{self.test_id} : FW Update Capable")
-            else:
-                step1.add_log(
-                    LogSeverity.INFO, f"{self.test_id} : FW Update Not Required"
-                )
-
-        step2 = self.test_run().add_step(f"{self.__class__.__name__} run(), step2")  # type: ignore
-        with step2.scope():
-            if self.group.fw_update_ifc.ctam_stage_fw(
-                image_type="empty_component", 
-                corrupted_component_id=corrupted_component_id
-                ):
-                step2.add_log(LogSeverity.INFO, f"{self.test_id} : FW Update Staged")
-            else:
-                step2.add_log(
-                    LogSeverity.ERROR, f"{self.test_id} : FW Update Stage Failed"
+        step0 = self.test_run().add_step(f"{self.__class__.__name__} run(), step0")  # type: ignore
+        with step0.scope():
+            self.corrupted_component_id = self.group.fw_update_ifc.ctam_get_component_to_be_corrupted()
+            if self.corrupted_component_id is None:
+                step0.add_log(
+                    LogSeverity.ERROR, f"{self.test_id} : Corrupt Component Id Retrieval Failed"
                 )
                 result = False
+            else:
+                step0.add_log(LogSeverity.INFO, f"{self.test_id} : Corrupt Component Id Retrieved")
+
+        if result:
+            step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
+            with step1.scope():
+                if not self.group.fw_update_ifc.ctam_fw_update_precheck():
+                    step1.add_log(LogSeverity.INFO, f"{self.test_id} : FW Update Capable")
+                else:
+                    step1.add_log(
+                        LogSeverity.INFO, f"{self.test_id} : FW Update Not Required"
+                    )
+
+            step2 = self.test_run().add_step(f"{self.__class__.__name__} run(), step2")  # type: ignore
+            with step2.scope():
+                if self.group.fw_update_ifc.ctam_stage_fw(
+                    image_type="corrupt_component", 
+                    corrupted_component_id=self.corrupted_component_id
+                    ):
+                    step2.add_log(LogSeverity.INFO, f"{self.test_id} : FW Update Staged")
+                else:
+                    step2.add_log(
+                        LogSeverity.ERROR, f"{self.test_id} : FW Update Stage Failed"
+                    )
+                    result = False
 
         if result:
             step3 = self.test_run().add_step(f"{self.__class__.__name__} run(), step3")  # type: ignore
@@ -108,7 +121,7 @@ class CTAMTestFullDeviceUpdateActivationWithFailedComponent(TestCase):
             step4 = self.test_run().add_step(f"{self.__class__.__name__} run(), step4")
             with step4.scope():
                 if self.group.fw_update_ifc.ctam_fw_update_verify(image_type="corrupt_component", 
-                                                                  corrupted_component_id=corrupted_component_id
+                                                                  corrupted_component_id=self.corrupted_component_id
                                                                   ):
                     step4.add_log(
                         LogSeverity.INFO,

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_staging_with_failed_component.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_staging_with_failed_component.py
@@ -9,6 +9,8 @@ LICENSE file in the root directory of this source tree.
 :Score Weight:	10
 
 :Description:	Firmware Update Stack Robustness Test. If one component copying (staging) fails, verify other component copying (staging) goes through.
+                Vendor needs to provide a fwpkg where a component image is corrupted, and all other component images are good (i.e. it will not fail the update).
+                
 :Usage 1:		python ctam.py -w ..\workspace -t F55
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Full Device Update Staging With Failed Component"
 
@@ -47,6 +49,7 @@ class CTAMTestFullDeviceUpdateStagingWithFailedComponent(TestCase):
         """
         super().__init__()
         self.group = group
+        self.corrupted_component_id = None
 
     def setup(self):
         """
@@ -66,29 +69,39 @@ class CTAMTestFullDeviceUpdateStagingWithFailedComponent(TestCase):
         """
         result = True
         
-        self.corrupted_component_id = self.group.fw_update_ifc.ctam_get_component_to_be_corrupted()
-
-        step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
-        with step1.scope():
-            if not self.group.fw_update_ifc.ctam_fw_update_precheck():
-                step1.add_log(LogSeverity.INFO, f"{self.test_id} : FW Update Capable")
-            else:
-                step1.add_log(
-                    LogSeverity.INFO, f"{self.test_id} : FW Update Not Required"
-                )
-
-        step2 = self.test_run().add_step(f"{self.__class__.__name__} run(), step2")  # type: ignore
-        with step2.scope():
-            if self.group.fw_update_ifc.ctam_stage_fw(
-                image_type="empty_component", 
-                corrupted_component_id=self.corrupted_component_id
-                ):
-                step2.add_log(LogSeverity.INFO, f"{self.test_id} : FW Update Staged")
-            else:
-                step2.add_log(
-                    LogSeverity.ERROR, f"{self.test_id} : FW Update Stage Failed"
+        step0 = self.test_run().add_step(f"{self.__class__.__name__} run(), step0")  # type: ignore
+        with step0.scope():
+            self.corrupted_component_id = self.group.fw_update_ifc.ctam_get_component_to_be_corrupted()
+            if self.corrupted_component_id is None:
+                step0.add_log(
+                    LogSeverity.ERROR, f"{self.test_id} : Corrupt Component Id Retrieval Failed"
                 )
                 result = False
+            else:
+                step0.add_log(LogSeverity.INFO, f"{self.test_id} : Corrupt Component Id Retrieved")
+
+        if result:
+            step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
+            with step1.scope():
+                if not self.group.fw_update_ifc.ctam_fw_update_precheck():
+                    step1.add_log(LogSeverity.INFO, f"{self.test_id} : FW Update Capable")
+                else:
+                    step1.add_log(
+                        LogSeverity.INFO, f"{self.test_id} : FW Update Not Required"
+                    )
+
+            step2 = self.test_run().add_step(f"{self.__class__.__name__} run(), step2")  # type: ignore
+            with step2.scope():
+                if self.group.fw_update_ifc.ctam_stage_fw(
+                    image_type="corrupt_component", 
+                    corrupted_component_id=self.corrupted_component_id
+                    ):
+                    step2.add_log(LogSeverity.INFO, f"{self.test_id} : FW Update Staged")
+                else:
+                    step2.add_log(
+                        LogSeverity.ERROR, f"{self.test_id} : FW Update Stage Failed"
+                    )
+                    result = False
 
         # ensure setting of self.result and self.score prior to calling super().run()
         self.result = TestResult.PASS if result else TestResult.FAIL

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_unsigned_bundle_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_unsigned_bundle_update.py
@@ -1,18 +1,19 @@
 """
-Copyright (c) Microsoft Corporation
+Copyright (c) NVIDIA CORPORATION
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 
-:Test Name:		CTAM Test Negative Unsigned Image Update
-:Test ID:		F18
+:Test Name:		CTAM Test Negative Unsigned Bundle Update
+:Test ID:		F90
 :Group Name:	fw_update
 :Score Weight:	10
 
-:Description:	This test case is a Negative test. It would search for GPU_FW_IMAGE_UNSIGNED referenced by package_info.json and attempt
-                firmware update using the unsigned image.
+:Description:	This test case is a Negative test. It would search for GPU_FW_IMAGE_UNSIGNED_BUNDLE referenced by package_info.json.
+                If the nudle is not provided, it will modify GPU_FW_IMAGE (golden fwpkg) for this test. Then it will attempt
+                firmware update using the Unsigned Bundle.
 
-:Usage 1:		python ctam.py -w ..\workspace -t F18
-:Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Negative Unsigned Image Update"
+:Usage 1:		python ctam.py -w ..\workspace -t F90
+:Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Negative Unsigned Bundle Update"
 
 """
 
@@ -30,16 +31,16 @@ from tests.fw_update.fw_update_group_N._fw_update_group_N import (
 )
 
 
-class CTAMTestNegativeUnsignedImageUpdate(TestCase):
+class CTAMTestNegativeUnsignedBundleUpdate(TestCase):
     """
-    Test case which attempts an unsigned image update
+    Test case which attempts an Unsigned Bundle update
 
     :param TestCase: super class for all test cases
     :type TestCase:
     """
 
-    test_name: str = "CTAM Test Negative Unsigned Image Update"
-    test_id: str = "F18"
+    test_name: str = "CTAM Test Negative Unsigned Bundle Update"
+    test_id: str = "F90"
     score_weight: int = 10
     tags: List[str] = ["Negative"]
 
@@ -69,7 +70,7 @@ class CTAMTestNegativeUnsignedImageUpdate(TestCase):
         result = True
         step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
         with step1.scope():
-            if self.group.fw_update_ifc.ctam_stage_fw(partial=1, image_type="unsigned"):
+            if self.group.fw_update_ifc.ctam_stage_fw(partial=1, image_type="unsigned_bundle"):
                 step1.add_log(
                     LogSeverity.INFO,
                     f"{self.test_id} : FW Update Stage Initiation Failed as Expected",

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_unsigned_component_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_unsigned_component_image_update.py
@@ -1,0 +1,103 @@
+"""
+Copyright (c) Microsoft Corporation
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+
+:Test Name:		CTAM Test Negative Unsigned Image Update
+:Test ID:		F18
+:Group Name:	fw_update
+:Score Weight:	10
+
+:Description:	This test case is a Negative test. It would search for GPU_FW_IMAGE_UNSIGNED referenced by package_info.json and attempt
+                firmware update using the unsigned image.
+
+:Usage 1:		python ctam.py -w ..\workspace -t F18
+:Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Negative Unsigned Image Update"
+
+"""
+
+from typing import Optional, List
+from tests.test_case import TestCase
+from ocptv.output import (
+    DiagnosisType,
+    LogSeverity,
+    SoftwareType,
+    TestResult,
+    TestStatus,
+)
+from tests.fw_update.fw_update_group_N._fw_update_group_N import (
+    FWUpdateTestGroupN,
+)
+
+
+class CTAMTestNegativeUnsignedImageUpdate(TestCase):
+    """
+    Test case which attempts an unsigned image update
+
+    :param TestCase: super class for all test cases
+    :type TestCase:
+    """
+
+    test_name: str = "CTAM Test Negative Unsigned Image Update"
+    test_id: str = "F18"
+    score_weight: int = 10
+    tags: List[str] = ["Negative"]
+
+    def __init__(self, group: FWUpdateTestGroupN):
+        """
+        _summary_
+        """
+        super().__init__()
+        self.group = group
+
+    def setup(self):
+        """
+        set environment state for this test only
+        """
+        # call super first
+        super().setup()
+
+        # add custom setup here
+        step1 = self.test_run().add_step(f"{self.__class__.__name__}  setup()...")
+        with step1.scope():
+            pass
+
+    def run(self) -> TestResult:
+        """
+        actual test verification
+        """
+        result = True
+        step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
+        with step1.scope():
+            if self.group.fw_update_ifc.ctam_stage_fw(partial=1, image_type="unsigned_component_image"):
+                step1.add_log(
+                    LogSeverity.INFO,
+                    f"{self.test_id} : FW Update Stage Initiation Failed as Expected",
+                )
+            else:
+                step1.add_log(
+                    LogSeverity.ERROR,
+                    f"{self.test_id} : FW Update Staging Initiated - Unexpected",
+                )
+                result = False
+
+        # ensure setting of self.result and self.score prior to calling super().run()
+        self.result = TestResult.PASS if result else TestResult.FAIL
+        if self.result == TestResult.PASS:
+            self.score = self.score_weight
+
+        # call super last to log result and score
+        super().run()
+        return self.result
+
+    def teardown(self):
+        """
+        undo environment state change from setup() above, this function is called even if run() fails or raises exception
+        """
+        # add custom teardown here
+        step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
+        with step1.scope():
+            pass
+
+        # call super teardown last
+        super().teardown()

--- a/ctam/utils/fwpkg_utils.py
+++ b/ctam/utils/fwpkg_utils.py
@@ -14,6 +14,12 @@ import shutil
 import uuid
 import math
 
+def copy_fwpkg(golden_fwpkg_path):
+    # Make a copy of the given fwpkg
+    corrupted_package =  os.path.join(os.path.dirname(golden_fwpkg_path), "corrupted-pkg.fwpkg")
+    corrupted_package_path = shutil.copy(golden_fwpkg_path, corrupted_package)
+    return corrupted_package_path
+    
 class PLDMFwpkg:
     """
     Methods related to PLDM fwpkg in general
@@ -29,9 +35,7 @@ class PLDMFwpkg:
         :returns:                           Path to corrupted package. None if corruption fails. 
         :rtype:                             str
         """
-        # Make a copy of the golden fwpkg
-        corrupted_package =  os.path.join(os.path.dirname(golden_fwpkg_path), "corrupted-pkg.fwpkg")
-        corrupted_package_path = shutil.copy(golden_fwpkg_path, corrupted_package)
+        corrupted_package_path = copy_fwpkg(golden_fwpkg_path)
         try:
             with open(corrupted_package_path, 'r+b') as file:
                 file.write(bytearray(16)) # UUID is 16 bytes
@@ -56,9 +60,7 @@ class PLDMFwpkg:
         :returns:                           Path to corrupted package. None if corruption fails. 
         :rtype:                             str
         """
-        # Make a copy of the golden fwpkg
-        corrupted_package =  os.path.join(os.path.dirname(golden_fwpkg_path), "corrupted-pkg.fwpkg")
-        corrupted_package_path = shutil.copy(golden_fwpkg_path, corrupted_package)
+        corrupted_package_path = copy_fwpkg(golden_fwpkg_path)
         
         pldm_parser = PLDMUnpack(corrupted_package_path)
         if result := pldm_parser.parse_pldm_package():
@@ -85,9 +87,7 @@ class PLDMFwpkg:
         :returns:                           Path to corrupted package. None if corruption fails. 
         :rtype:                             str
         """
-        # Make a copy of the golden fwpkg
-        corrupted_package =  os.path.join(os.path.dirname(golden_fwpkg_path), "corrupted-pkg.fwpkg")
-        corrupted_package_path = shutil.copy(golden_fwpkg_path, corrupted_package)
+        corrupted_package_path = copy_fwpkg(golden_fwpkg_path)
         
         pldm_parser = PLDMUnpack(corrupted_package_path)
         if result := pldm_parser.parse_pldm_package():
@@ -113,9 +113,7 @@ class PLDMFwpkg:
         :returns:                           Path to corrupted package. None if corruption fails. 
         :rtype:                             str
         """
-        # Make a copy of the golden fwpkg
-        corrupted_package =  os.path.join(os.path.dirname(golden_fwpkg_path), "corrupted-pkg.fwpkg")
-        corrupted_package_path = shutil.copy(golden_fwpkg_path, corrupted_package)
+        corrupted_package_path = copy_fwpkg(golden_fwpkg_path)
         
         pldm_parser = PLDMUnpack(corrupted_package_path)
         if result := pldm_parser.parse_pldm_package():
@@ -140,9 +138,7 @@ class PLDMFwpkg:
         :returns:                           Path to corrupted package. None if corruption fails. 
         :rtype:                             str
         """
-        # Make a copy of the golden fwpkg
-        corrupted_package =  os.path.join(os.path.dirname(golden_fwpkg_path), "corrupted-pkg.fwpkg")
-        corrupted_package_path = shutil.copy(golden_fwpkg_path, corrupted_package)
+        corrupted_package_path = copy_fwpkg(golden_fwpkg_path)
         
         with open(golden_fwpkg_path, 'rb') as infile:
             golden_fwpkg_content = infile.read()
@@ -169,9 +165,7 @@ class PLDMFwpkg:
         :returns:                           Path to corrupted package. None if corruption fails. 
         :rtype:                             str
         """
-        # Make a copy of the golden fwpkg
-        corrupted_package =  os.path.join(os.path.dirname(golden_fwpkg_path), "corrupted-pkg.fwpkg")
-        corrupted_package_path = shutil.copy(golden_fwpkg_path, corrupted_package)
+        corrupted_package_path = copy_fwpkg(golden_fwpkg_path)
         
         pldm_parser = PLDMUnpack(corrupted_package_path)
         result = pldm_parser.corrupt_device_record_uuid_in_pkg()
@@ -245,16 +239,14 @@ class FwpkgSignature:
         :returns:                           Path to corrupted package. None if corruption fails. 
         :rtype:                             str
         """
-        major_package_version, _ = get_major_minor_version_of_package_signature(golden_fwpkg_path)
+        major_package_version, _ = FwpkgSignature.get_major_minor_version_of_package_signature(golden_fwpkg_path)
         if int(major_package_version) not in [FwpkgSignature.HeaderV2, FwpkgSignature.HeaderV3]:
             print(
                 f"Package Major Version is not supported: {major_package_version}"
             )
             return None
         
-        # Make a copy of the golden fwpkg
-        corrupted_package =  os.path.join(os.path.dirname(golden_fwpkg_path), "corrupted-pkg.fwpkg")
-        corrupted_package_path = shutil.copy(golden_fwpkg_path, corrupted_package)
+        corrupted_package_path = copy_fwpkg(golden_fwpkg_path)
         
         if not corrupt_single_byte_in_package_signature(corrupted_package_path, 13, 255):
             print("Failed to corrupt the signature type")
@@ -274,10 +266,7 @@ class FwpkgSignature:
         :returns:                           Path to corrupted package. None if corruption fails. 
         :rtype:                             str
         """
-        # Make a copy of the golden fwpkg
-        corrupted_package =  os.path.join(os.path.dirname(golden_fwpkg_path), "corrupted-pkg.fwpkg")
-        corrupted_package_path = shutil.copy(golden_fwpkg_path, corrupted_package)
-        
+        corrupted_package_path = copy_fwpkg(golden_fwpkg_path)
         try:
             with open(corrupted_package_path, 'r+b') as file:
                 file.seek(-FwpkgSignature.PKG_SIGNATURE_STRUCT_BYTES, os.SEEK_END)
@@ -290,7 +279,7 @@ class FwpkgSignature:
         return corrupted_package_path
 
     @staticmethod
-    def clear_signature_in_pkg(golden_fwpkg_path):
+    def clear_entire_signature_in_pkg(golden_fwpkg_path):
         """
         :Description:                       Clear the signature data appended at the end of
                                             the PLDM bundle.
@@ -300,13 +289,49 @@ class FwpkgSignature:
         :returns:                           Path to corrupted package. None if corruption fails. 
         :rtype:                             str
         """
-        # Make a copy of the golden fwpkg
-        corrupted_package =  os.path.join(os.path.dirname(golden_fwpkg_path), "corrupted-pkg.fwpkg")
-        corrupted_package_path = shutil.copy(golden_fwpkg_path, corrupted_package)
+        corrupted_package_path = copy_fwpkg(golden_fwpkg_path)
         try:
             with open(corrupted_package_path, 'r+b') as file:
                 file.seek(-FwpkgSignature.PKG_SIGNATURE_STRUCT_BYTES, os.SEEK_END)
                 file.write(bytearray(FwpkgSignature.PKG_SIGNATURE_STRUCT_BYTES))
+        except Exception as e:
+            print(f"Error in corrupting the package: {e}")
+            # delete the package
+            os.remove(corrupted_package_path)
+            corrupted_package_path = None
+            
+        return corrupted_package_path
+    
+    @staticmethod
+    def clear_signature_in_pkg(golden_fwpkg_path):
+        """
+        :Description:                       Clear the signature field in the PLDM bundle signature.
+
+        :param str golden_fwpkg_path:	    Path to golden firmware package
+
+        :returns:                           Path to corrupted package. None if corruption fails. 
+        :rtype:                             str
+        """
+        major_package_version, _ = FwpkgSignature.get_major_minor_version_of_package_signature(golden_fwpkg_path)
+        if int(major_package_version) not in [FwpkgSignature.HeaderV2, FwpkgSignature.HeaderV3]:
+            print(
+                f"Package Major Version is not supported: {major_package_version}"
+            )
+            return None
+        
+        corrupted_package_path = copy_fwpkg(golden_fwpkg_path)
+        try:
+            with open(corrupted_package_path, 'r+b') as file:
+                signature_offset_index = 7 # Magic number is at index 0
+                file.seek(-FwpkgSignature.PKG_SIGNATURE_STRUCT_BYTES + signature_offset_index, os.SEEK_END)
+                signature_offset = int.from_bytes(file.read(2),
+                                                 byteorder='big',
+                                                 signed=False) # Offset to Signature is UINT16
+                file.seek(-FwpkgSignature.PKG_SIGNATURE_STRUCT_BYTES+signature_offset, os.SEEK_END) # Move to signature size index
+                signature_size = int.from_bytes(file.read(2),
+                                                 byteorder='big',
+                                                 signed=False) # Signature Size  is UINT16
+                file.write(bytearray(signature_size))
         except Exception as e:
             print(f"Error in corrupting the package: {e}")
             # delete the package
@@ -580,7 +605,9 @@ class PLDMUnpack:
         :rtype:                             bool
         """
         corruption_status = False
-        package_size = os.path.getsize(self.package)
+        with open(self.package, 'rb') as infile:
+            fwpkg_content = infile.read()
+        package_size = os.path.getsize(fwpkg_content)
         for index, info in enumerate(self.component_img_info_list):
             if component_id is not None and info["ComponentIdentifier"] != hex(int(component_id, 16)):
                 continue
@@ -617,7 +644,9 @@ class PLDMUnpack:
         :rtype:                             bool
         """
         corruption_status = False
-        package_size = os.path.getsize(self.package)
+        with open(self.package, 'rb') as infile:
+            fwpkg_content = infile.read()
+        package_size = os.path.getsize(fwpkg_content)
         for index, info in enumerate(self.component_img_info_list):
             if component_id is not None and info["ComponentIdentifier"] != hex(int(component_id, 16)):
                 continue
@@ -652,7 +681,9 @@ class PLDMUnpack:
         :rtype:                             bool
         """
         corruption_status = False
-        package_size = os.path.getsize(self.package)
+        with open(self.package, 'rb') as infile:
+            fwpkg_content = infile.read()
+        package_size = os.path.getsize(fwpkg_content)
         for index, info in enumerate(self.component_img_info_list):
             if component_id is not None and info["ComponentIdentifier"] != hex(int(component_id, 16)):
                 continue

--- a/json_spec/input/package_info.json
+++ b/json_spec/input/package_info.json
@@ -40,7 +40,14 @@
     "JSON": "",
     "Vendor": ""
   },
-  "GPU_FW_IMAGE_UNSIGNED": {
+  "GPU_FW_IMAGE_UNSIGNED_COMPONENT": {
+    "Path": "workspace",
+    "Package": "",
+    "Version": "",
+    "JSON": "",
+    "Vendor": ""
+  },
+  "GPU_FW_IMAGE_UNSIGNED_BUNDLE": {
     "Path": "workspace",
     "Package": "",
     "Version": "",
@@ -55,6 +62,10 @@
     "Vendor": ""
   },
   "GPU_FW_IMAGE_CORRUPT_COMPONENT": {
+    "Path": "workspace",
+    "Package": "",
+    "Version": "",
+    "JSON": "",
     "CorruptComponentIdentifier": "",
     "MetadataSizeBytes": 4096,
     "Vendor": ""


### PR DESCRIPTION
**Major Fixes:**
- Fixed issue in F89 (Single Device Update Ping Pong) with httppushuritarget selection resetting to [] after power cycle in first iteration.
- Updated F55 and F56 to require corrupt bundle from vendor.
- Renamed F18 to "Unsigned Image Update"
- Added F90 for negative test with Unsigned Bundle

**Test Result:**
TestID | TestName | ExecutionTime | TestScoreWeight | TestScore | TestResult
-- | -- | -- | -- | -- | --
F1 | CTAM Test Full Device Update | 0:20:33.697000 | 10 | 10 | PASS
F18 | CTAM Test Negative Unsigned Image Update | 0:01:09.910000 | 10 | 10 | PASS
F90 | CTAM Test Negative Unsigned Bundle Update | 0:00:20.730000 | 10 | 10 | PASS
F89 | CTAM Test Single Device Update Ping Pong | 0:10:07.815000 | 10 | 10 | PASS
F55 | CTAM Test Full Device Update Staging With Failed Component | 0:11:34.632000 | 10 | 10 | PASS
F56 | CTAM Test Full Device Update Activation With Failed Component | 0:15:59.992000 | 10 | 10 | PASS

