### PR TITLE
Developer msft

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,21 @@ This project is part of [OCPTV](https://github.com/opencomputeproject/ocp-diag-c
 2. console_log - True/False (for console logs)
 3. progress_bar - True/False (for progress bar idicator)
 
+## Tags
+
+### 1. Group Tag
+
+- We can give tags at group level also.
+- If we provide any tag to a particular group, then all the test case under that group will be considered as the same tag.
+- If we run according to group tag, then all the test case will run under the group irrespective of the test case tag. 
+
+### 2. Test Case Tags
+- We can assign different tags to different test cases.
+- If we run according to test case tag, then all the test cases which assigned with that tag would run irrespective of group tags.
+
+**Note: - Tags = Group Tags Union Test Case Tags
+group tags = ["G1"] and test case tags = ["L1"], so the final tags will be ["G1", "L1"]**
+
 ## Developer notes
 ### VS Code
 

--- a/ctam/ctam.py
+++ b/ctam/ctam.py
@@ -204,7 +204,7 @@ def main():
                 package_info_json_file=package_info_json,
                 net_rc=net_rc,
                 redfish_uri_config_file=redfish_uri_config,
-                sequence_test_override=all_tests
+                run_all_tests=all_tests
             )
 
         status_code, exit_string = runner.run()

--- a/ctam/ctam.py
+++ b/ctam/ctam.py
@@ -123,8 +123,6 @@ def main():
             return 1, None, "Invalid workspace specified"
         required_workspace_files = [
             "dut_info.json",
-            "package_info.json",
-            "test_runner.json",
             "redfish_uri_config.json",
             ".netrc",
         ]
@@ -145,6 +143,7 @@ def main():
         net_rc = os.path.join(args.workspace, ".netrc")
         if args.Discovery:
             runner = TestRunner(
+                workspace_dir=args.workspace,
                 test_hierarchy=test_hierarchy,
                 test_runner_json_file=test_runner_json,
                 dut_info_json_file=dut_info_json,
@@ -157,6 +156,7 @@ def main():
 
         elif args.testcase:
             runner = TestRunner(
+                workspace_dir=args.workspace,
                 test_hierarchy=test_hierarchy,
                 test_runner_json_file=test_runner_json,
                 dut_info_json_file=dut_info_json,
@@ -167,6 +167,7 @@ def main():
             )
         elif args.testcase_sequence:
             runner = TestRunner(
+                workspace_dir=args.workspace,
                 test_hierarchy=test_hierarchy,
                 test_runner_json_file=test_runner_json,
                 dut_info_json_file=dut_info_json,
@@ -177,6 +178,7 @@ def main():
             )
         elif args.group:
             runner = TestRunner(
+                workspace_dir=args.workspace,
                 test_hierarchy=test_hierarchy,
                 test_runner_json_file=test_runner_json,
                 dut_info_json_file=dut_info_json,
@@ -187,6 +189,7 @@ def main():
             )
         elif args.group_sequence:
             runner = TestRunner(
+                workspace_dir=args.workspace,
                 test_hierarchy=test_hierarchy,
                 test_runner_json_file=test_runner_json,
                 dut_info_json_file=dut_info_json,
@@ -198,6 +201,7 @@ def main():
         else:
             all_tests = test_hierarchy.get_all_tests()
             runner = TestRunner(
+                workspace_dir=args.workspace,
                 test_hierarchy=test_hierarchy,
                 test_runner_json_file=test_runner_json,
                 dut_info_json_file=dut_info_json,

--- a/ctam/ctam.py
+++ b/ctam/ctam.py
@@ -196,6 +196,7 @@ def main():
                 sequence_group_override=args.group_sequence,
             )
         else:
+            all_tests = test_hierarchy.get_all_tests()
             runner = TestRunner(
                 test_hierarchy=test_hierarchy,
                 test_runner_json_file=test_runner_json,
@@ -203,6 +204,7 @@ def main():
                 package_info_json_file=package_info_json,
                 net_rc=net_rc,
                 redfish_uri_config_file=redfish_uri_config,
+                sequence_test_override=all_tests
             )
 
         status_code, exit_string = runner.run()

--- a/ctam/interfaces/comptool_dut.py
+++ b/ctam/interfaces/comptool_dut.py
@@ -418,15 +418,12 @@ class CompToolDut(Dut):
     
     def validate_redfish_service(self, file_name, uri, depth, *args, **kwargs):
         log_path = os.path.join(self.logger_path, file_name)
-        print(log_path)
         try:
-            print("@@@@")
             file_name = os.path.join(self.repo_path, file_name)
             base_uri = self.uri_builder.format_uri(redfish_str="{GPUMC}",
                                                                 component_type="GPU")
             ip = self.connection_ip_address + base_uri
             schema_directory = os.path.join(self.repo_path, "SchemaFiles")
-            print("+++++")
             run_command = "python {file_name}.py --ip {ip} \
                 -u {user} -p {pwd} --logdir {log_dir} \
                 --schema_directory {schema_directory} \

--- a/ctam/interfaces/comptool_dut.py
+++ b/ctam/interfaces/comptool_dut.py
@@ -453,8 +453,17 @@ class CompToolDut(Dut):
                 bar()
                 if result.stderr:
                     raise Exception(result.stderr)
+            result = result.stdout.decode("utf-8").strip()
+            data = result.replace("\r", "").split("\n")[-1]
+            if "fail" in data.lower():
+                msg = "Redfish ServiceVerification has failed. Please check log file for more details."
+                msg += "\n{}".format(self.logger_path)
+                self.test_info_logger.log(msg)
+                return False
+            return True
         except Exception as e:
             print(f"Exception Occurred: {e}")
+            return False
     
     def validate_redfish_interop(self, file_name, uri, depth, *args, **kwargs):
         log_path = os.path.join(self.logger_path, file_name)

--- a/ctam/interfaces/comptool_dut.py
+++ b/ctam/interfaces/comptool_dut.py
@@ -149,7 +149,7 @@ class CompToolDut(Dut):
 
     @property
     def user_pass(self):
-        return self.__user_name
+        return self.__user_pass
     
     @user_pass.setter
     def user_pass(self, value):

--- a/ctam/interfaces/functional_ifc.py
+++ b/ctam/interfaces/functional_ifc.py
@@ -88,6 +88,8 @@ class FunctionalIfc:
         """
 
         # FIXME: Refactor.. Lots of repeated code
+        # if not self.dut().package_config:
+        #     raise Exception("Please provide data in package config file to run this test case...")
         if image_type == "default":
             json_fw_file_payload = os.path.join(
                 self.dut().cwd,
@@ -274,6 +276,8 @@ class FunctionalIfc:
         :returns:	            File path
         :rtype:                 string
         """
+        # if not self.dut().package_config:
+        #     raise Exception("Please provide data in package config file to run this test case...")
         pldm_json_file = ""
         if image_type == "default":
             pldm_json_file = os.path.join(
@@ -482,23 +486,29 @@ class FunctionalIfc:
         """
         MyName = __name__ + "." + self.NodeACReset.__qualname__
         command_to_run = ""
-        command_to_run = self.dut().dut_config["PowerOffCommand"]["value"]
+        command_to_run = self.dut().dut_config.get("PowerOffCommand", {}).get("value", "")
+        if not command_to_run:
+            self.test_run().add_log(LogSeverity.INFO, "Please provide the command in dut info for running power off.")
+            return 
         self.test_run().add_log(LogSeverity.INFO, json.dumps(command_to_run, indent=4))
         arguments = shlex.split(command_to_run)
         subprocess.check_output(arguments, cwd=os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
-        time.sleep(self.dut().dut_config["PowerOffWaitTime"]["value"])
+        time.sleep(self.dut().dut_config.get("PowerOffWaitTime", {}).get("value", 60))
         self.test_run().add_log(LogSeverity.INFO, "Power Off wait time done")
-        command_to_run = self.dut().dut_config["PowerOnCommand"]["value"]
+        command_to_run = self.dut().dut_config.get("PowerOnCommand", {}).get("value", "")
+        if not command_to_run:
+            self.test_run().add_log(LogSeverity.INFO, "Please provide the power on command in dut info to run.")
+            return 
         self.test_run().add_log(LogSeverity.INFO, json.dumps(command_to_run, indent=4))
         arguments = shlex.split(command_to_run)
         subprocess.check_output(arguments, cwd=os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
-        time.sleep(self.dut().dut_config["PowerOnWaitTime"]["value"])
+        time.sleep(self.dut().dut_config.get("PowerOnWaitTime", {}).get("value", 300))
         self.test_run().add_log(LogSeverity.INFO, "Power ON wait time done")
         return
 
     def IsGPUReachable(self):
         """
-        :Description:        It will check fofr GPU is available or not using Redfish command
+        :Description:        It will check for GPU is available or not using Redfish command
 
         :returns:	         JSON data after executing redfish command
         :rtype:              JSON Dict

--- a/ctam/interfaces/fw_update_ifc.py
+++ b/ctam/interfaces/fw_update_ifc.py
@@ -157,10 +157,9 @@ class FWUpdateIfc(FunctionalIfc):
         """
         MyName = __name__ + "." + self.ctam_stage_fw.__qualname__
         StartTime = time.time()
-
-        if partial == 0:
+        pushtargets = self.dut().uri_builder.format_uri(redfish_str="{HttpPushUriTargets}", component_type="GPU")
+        if partial == 0 and pushtargets:
             self.ctam_pushtargets()
-
         JSONFWFilePayload = self.get_JSONFWFilePayload_file(image_type=image_type, corrupted_component_id=corrupted_component_id)
         if not os.path.isfile(JSONFWFilePayload):
             self.test_run().add_log(LogSeverity.DEBUG, f"Package file not found!!!")
@@ -571,10 +570,11 @@ class FWUpdateIfc(FunctionalIfc):
         if PLDMPkgJson_file and os.path.isfile(PLDMPkgJson_file):
             with open(PLDMPkgJson_file, "r") as f:
                 PLDMPkgJson = json.load(f)
-        
             # Now find the FW version for the software IDs in the PLDM bundle
+            
             for software_id in Updateable_SoftwareIds:
                 fw_versions = []
+
                 jsonhuntall(PLDMPkgJson,
                         "ComponentIdentifier",
                         str(int(software_id, 16)),
@@ -614,7 +614,7 @@ class FWUpdateIfc(FunctionalIfc):
                                         break
                                 for comp_index in ApplicableComponents:
                                     comp_info =  PLDMPkgJson.get("ComponentImageInformationArea", {}).get("ComponentImageInformation", [])[comp_index]
-                                    if comp_info["ComponentIdentifier"] == str(int(software_id, 16)):
+                                    if comp_info["ComponentIdentifier"] == str(hex(int(software_id, 16))):
                                         ComponentVersions[software_id] = comp_info["ComponentVersionString"]
                                         break
         else:

--- a/ctam/interfaces/fw_update_ifc.py
+++ b/ctam/interfaces/fw_update_ifc.py
@@ -622,9 +622,13 @@ class FWUpdateIfc(FunctionalIfc):
     
     def ctam_delay_between_testcases(self):
         MyName = __name__ + "." + self.ctam_delay_between_testcases.__qualname__
-        time.sleep(600)
-        msg = "Execution is delayed by 600 seconds."
-        self.test_run().add_log(LogSeverity.DEBUG, msg)                       
+        IdleWaitTime = self.dut().dut_config["IdleWaitTimeAfterFirmwareUpdate"]["value"]
+        msg = f"Execution will be delayed by {IdleWaitTime} seconds."
+        self.test_run().add_log(LogSeverity.DEBUG, msg)
+        time.sleep(IdleWaitTime)
+        msg = f"Execution is delayed successfully by {IdleWaitTime} seconds."
+        self.test_run().add_log(LogSeverity.DEBUG, msg)
+        return True
                             
                             
                             

--- a/ctam/interfaces/fw_update_ifc.py
+++ b/ctam/interfaces/fw_update_ifc.py
@@ -619,7 +619,12 @@ class FWUpdateIfc(FunctionalIfc):
             msg = "PLDMPkgJson file not found."
             self.test_run().add_log(LogSeverity.DEBUG, msg)    
         return ComponentVersions
-                                            
+    
+    def ctam_delay_between_testcases(self):
+        MyName = __name__ + "." + self.ctam_delay_between_testcases.__qualname__
+        time.sleep(600)
+        msg = "Execution is delayed by 600 seconds."
+        self.test_run().add_log(LogSeverity.DEBUG, msg)                       
                             
                             
                             

--- a/ctam/interfaces/fw_update_ifc.py
+++ b/ctam/interfaces/fw_update_ifc.py
@@ -162,7 +162,9 @@ class FWUpdateIfc(FunctionalIfc):
             self.ctam_pushtargets()
 
         JSONFWFilePayload = self.get_JSONFWFilePayload_file(image_type=image_type, corrupted_component_id=corrupted_component_id)
-
+        if not os.path.isfile(JSONFWFilePayload):
+            self.test_run().add_log(LogSeverity.DEBUG, f"Package file not found!!!")
+            return False
         if self.dut().is_debug_mode():
             print(JSONFWFilePayload)
         uri = self.dut().uri_builder.format_uri(

--- a/ctam/interfaces/health_check_ifc.py
+++ b/ctam/interfaces/health_check_ifc.py
@@ -112,12 +112,12 @@ class HealthCheckIfc(FunctionalIfc):
             #print(clear_dump_uri)
             uri = self.dut().uri_builder.format_uri(redfish_str="{GPUMC}" + "{}".format(clear_dump_uri), component_type="GPU")
             response = self.dut().run_redfish_command(uri=uri, mode="POST")
-            if response is None or response.status != 204:
-                result = False
-                self.write_test_info("Clearing Log Dump Action Unsuccessful")
-            else:
+            if response is not None or response.status == 204 or response.status == 200:
                 result = True
                 self.write_test_info("Clearing Log Dump Action Successful")
+            else:
+                result = False
+                self.write_test_info("Clearing Log Dump Action Unsuccessful")
         return result
     
     def trigger_self_test_dump_collection(self):

--- a/ctam/test_hierarchy.py
+++ b/ctam/test_hierarchy.py
@@ -446,3 +446,10 @@ class TestHierarchy:
                             raise
 
         return instances
+
+    def get_all_tests(self):
+        all_tests = []
+        for group_name, group_info in self.test_groups.items():
+            for testcase in group_info["test_cases"]:
+                all_tests.append(testcase["attributes"]["test_id"])
+        return all_tests

--- a/ctam/test_hierarchy.py
+++ b/ctam/test_hierarchy.py
@@ -277,7 +277,7 @@ class TestHierarchy:
                 print(f"No test group named {group_name} found.")
         
         # print the table now
-        t.align["TestCaseName"] = "l"
+        t.align = "l"
         print(t)
 
     def _find_testcase(self, param):

--- a/ctam/test_hierarchy.py
+++ b/ctam/test_hierarchy.py
@@ -136,6 +136,7 @@ class TestHierarchy:
             for file_name in files:
                 if file_name.endswith(".py"):
                     module_name = file_name[:-3]  # Remove the .py extension
+                    
                     module_path = os.path.join(root, file_name)
 
                     with open(module_path, "r") as f:
@@ -171,6 +172,7 @@ class TestHierarchy:
                     os.path.join(root, dir)
                 )  # add test group dirs to python search path
                 test_group_dir = os.path.join(root, dir)
+                
                 for filename in os.listdir(test_group_dir):
                     if filename.endswith(".py"):
                         with open(os.path.join(test_group_dir, filename), "r") as f:
@@ -319,6 +321,30 @@ class TestHierarchy:
                 return group_info
         return None
 
+    def get_domains(self):
+        domains = {}
+        for group_name, group_info in self.test_groups.items():
+            d_name = group_info[
+                "group_attributes"
+            ].get("domain_name")
+            if d_name and d_name not in domains:
+                domains[d_name] = len(group_info["test_cases"])
+            elif d_name and d_name in domains:
+                domains[d_name] += len(group_info["test_cases"])
+        return domains
+    
+    def get_compliance_test_cases(self):
+        compliance_test_count = {}
+        for group_name, group_info in self.test_groups.items():
+            for testcase in group_info["test_cases"]:
+                # Check if the param matches the testcase name or the test_id
+                c_data = testcase["attributes"].get("compliance_level")
+                if c_data and c_data not in compliance_test_count:
+                    compliance_test_count[c_data] = 1
+                elif c_data and c_data in compliance_test_count:
+                    compliance_test_count[c_data] += 1     
+        return compliance_test_count  
+    
     def _instantiate_object(self, obj_info, class_name, init_param=None):
         """
         Used to instantiate a TestGroup or TestCase

--- a/ctam/test_hierarchy.py
+++ b/ctam/test_hierarchy.py
@@ -14,6 +14,7 @@ import sys
 import os
 import ast
 from typing import List, Any
+from prettytable import PrettyTable
 
 
 class TestHierarchy:
@@ -235,27 +236,49 @@ class TestHierarchy:
         :param group_name: Name of group, defaults to None
         :type group_name: str, optional
         """
+        t = PrettyTable(["GroupID", "GroupName", "GroupTag", "TestCaseID", "TestCaseName", "TestCaseTag", "TestCaseWeightScore"])
+        t.title = "Test Case info table"
 
         def print_group_info(group_name, group_info):
-            print(f'\nGroup ID: {group_info["group_attributes"]["group_id"]}      Test Group Name: {group_name}')
+            total_cases = len(group_info["test_cases"])
+            if total_cases == 0:
+                t.add_row([group_info["group_attributes"]["group_id"], group_name, "", "", "", "", ""])
+                return
+            count = 0
+            # print(f'\nGroup ID: {group_info["group_attributes"]["group_id"]}      Test Group Name: {group_name}')
             for testcase in group_info["test_cases"]:
-                print(
-                    f'    Test Case ID: {testcase["attributes"]["test_id"]}      Test Case Name: {testcase["testcase_name"]}'
-                )
+                if count != total_cases//2:
+                    t.add_row(["", "", group_info["group_attributes"]["tags"],\
+                          testcase["attributes"]["test_id"], testcase["testcase_name"], testcase["attributes"]["tags"],\
+                             testcase["attributes"]["score_weight"]])
+                else:
+                    t.add_row([group_info["group_attributes"]["group_id"], group_name, group_info["group_attributes"]["tags"],\
+                          testcase["attributes"]["test_id"], testcase["testcase_name"], testcase["attributes"]["tags"],\
+                             testcase["attributes"]["score_weight"]])
+                count += 1
+                # print(
+                #     f'    Test Case ID: {testcase["attributes"]["test_id"]}      Test Case Name: {testcase["testcase_name"]}'
+                # )
 
         if group_name is None:
             # If no group name is specified, print all groups.
             for group_name, group_info in self.test_groups.items():
                 print_group_info(group_name, group_info)
+                t.add_row(["","","","","","",""], divider=True)
+                
         else:
             # Otherwise, print the specified group.
-            print(self.test_groups)
+            #print(self.test_groups)
             group_info = self._find_group(group_name)
             # group_info = self.test_groups.get(group_name)
             if group_info is not None:
                 print_group_info(group_name, group_info)
             else:
                 print(f"No test group named {group_name} found.")
+        
+        # print the table now
+        t.align["TestCaseName"] = "l"
+        print(t)
 
     def _find_testcase(self, param):
         """

--- a/ctam/test_runner.py
+++ b/ctam/test_runner.py
@@ -577,8 +577,12 @@ class TestRunner:
             self.generate_compliance_data(test_instance, "Others", self.weighted_scores["Others"], execution_time, total_test, test_passed, score_weight, score, grade)
 
     def generate_compliance_data(self, test_instance, c_level, l_weight, e_time, t_test, t_pass, s_weight, score, grade):
+        
         if c_level not in self.compliance_data:
-            grade = round((test_instance.score / test_instance.score_weight * 100), 2)
+            if test_instance.score_weight == 0:
+                grade = 0
+            else:
+                grade = round((test_instance.score / test_instance.score_weight * 100), 2)
             self.compliance_data[c_level] = [c_level,
                                             l_weight,
                                             e_time,
@@ -592,7 +596,10 @@ class TestRunner:
             data = self.compliance_data[c_level]
             sw = data[5] + test_instance.score_weight
             s = data[6] + test_instance.score
-            grade = round((s / sw * 100), 2)
+            if test_instance.score_weight == 0:
+                grade = 0
+            else:
+                grade = round((s / sw * 100), 2)
             self.compliance_data[c_level] = [c_level,
                                                 l_weight,
                                                 data[2] + e_time,

--- a/ctam/test_runner.py
+++ b/ctam/test_runner.py
@@ -54,6 +54,7 @@ class TestRunner:
         sequence_test_override=None,
         single_group_override=None,
         sequence_group_override=None,
+        run_all_tests=None,
     ):
         """
         Init function that handles test execution variations
@@ -157,6 +158,8 @@ class TestRunner:
                 raise Exception(
                     "active_test_suite in test_runner.json specifies missing List"
                 )
+        elif run_all_tests:
+            self.test_sequence = run_all_tests
         else:
             raise Exception(
                 "Specify test cases/groups with -t, -g command line options or use test_runner.json"

--- a/ctam/test_runner.py
+++ b/ctam/test_runner.py
@@ -315,18 +315,8 @@ class TestRunner:
                     ) = self.test_hierarchy.instantiate_obj_for_testcase(test)
 
                     group_inc_tags = group_instance.tags
+                    print("Group tags ", group_instance.tags)
                     # group_exc_tags = group_instance.exclude_tags
-                    valid = self._is_enabled(
-                        self.include_tags_set,
-                        group_inc_tags,
-                        self.exclude_tags_set,
-                        # group_exc_tags,
-                    )
-                    if not valid:
-                        print(
-                            f"Group1 {group_instance.__class__.__name__} skipped due to tags. tags = {group_inc_tags}"
-                        )
-                        continue
 
                     group_status, group_result = self._run_group_test_cases(group_instance, test_case_instances)
                     group_status_set.add(group_status)
@@ -344,17 +334,6 @@ class TestRunner:
                     
                     group_inc_tags = group_instance.tags
                     # group_exc_tags = group_instance.exclude_tags
-                    valid = self._is_enabled(
-                        self.include_tags_set,
-                        group_inc_tags,
-                        self.exclude_tags_set,
-                        # group_exc_tags,
-                    )
-                    if not valid:
-                        print(
-                            f"Group1 {group_instance.__class__.__name__} skipped due to tags. tags = {group_inc_tags}"
-                        )
-                        continue
 
                     group_status, group_result = self._run_group_test_cases(group_instance, test_case_instances)
                     group_status_set.add(group_status)
@@ -371,19 +350,6 @@ class TestRunner:
                         progress_thread.start()
                     group_inc_tags = group_instance.tags
                     # group_exc_tags = group_instance.exclude_tags
-
-                    valid = self._is_enabled(
-                        self.include_tags_set,
-                        group_inc_tags,
-                        self.exclude_tags_set,
-                        # group_exc_tags,
-                    )
-
-                    if not valid:
-                        print(
-                            f"Group2 {group_instance.__class__.__name__} skipped due to tags. tags = {group_inc_tags}"
-                        )
-                        continue
 
                     group_status, group_result = self._run_group_test_cases(group_instance, test_case_instances)
                     group_status_set.add(group_status)
@@ -407,19 +373,6 @@ class TestRunner:
 
                     group_inc_tags = group_instance.tags
                     # group_exc_tags = group_instance.exclude_tags
-
-                    valid = self._is_enabled(
-                        self.include_tags_set,
-                        group_inc_tags,
-                        self.exclude_tags_set,
-                        # group_exc_tags,
-                    )
-
-                    if not valid:
-                        print(
-                            f"Group2 {group_instance.__class__.__name__} skipped due to tags. tags = {group_inc_tags}"
-                        )
-                        continue
 
                     group_status, group_result = self._run_group_test_cases(group_instance, test_case_instances)
                     group_status_set.add(group_status)
@@ -485,13 +438,11 @@ class TestRunner:
 
             for test_instance in test_case_instances:
                 test_inc_tags = test_instance.tags
-                # test_exc_tags = test_instance.exclude_tags
-
+                tags = list(set(test_inc_tags) | set(group_instance.tags))
                 valid = self._is_enabled(
                     self.include_tags_set,
-                    test_inc_tags,
+                    tags,
                     self.exclude_tags_set,
-                    # test_exc_tags,
                 )
                 if not valid:
                     msg = f"Test {test_instance.__class__.__name__} skipped due to tags. tags = {test_inc_tags}"

--- a/ctam/tests/fw_update/fw_update_group_N/_fw_update_group_N.py
+++ b/ctam/tests/fw_update/fw_update_group_N/_fw_update_group_N.py
@@ -20,6 +20,7 @@ class FWUpdateTestGroupN(TestGroup):
 
     tags: List[str] = []
     group_id : str = "GFW1"
+    domain_name: str = "FWUpdate"
     # exclude_tags: List[str] = []
 
     def __init__(self):

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_activation_time.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_activation_time.py
@@ -58,7 +58,7 @@ class CTAMTestFullDeviceUpdateActivationTime(TestCase):
         # add custom setup here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  setup()...")
         with step1.scope():
-            self.group.fw_update_ifc.ctam_delay_between_testcases()
+            pass
 
     def run(self) -> TestResult:
         """
@@ -129,7 +129,7 @@ class CTAMTestFullDeviceUpdateActivationTime(TestCase):
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():
-            if self.group.fw_update_ifc.ctam_activate_ac():
+            if self.group.fw_update_ifc.ctam_activate_ac(check_time=False):
                 msg = f"{self.test_id} : AC Cycle Passed"
                 self.test_run().add_log(LogSeverity.DEBUG, msg)  
             else:

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_activation_time.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_activation_time.py
@@ -58,7 +58,7 @@ class CTAMTestFullDeviceUpdateActivationTime(TestCase):
         # add custom setup here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  setup()...")
         with step1.scope():
-            pass
+            self.group.fw_update_ifc.ctam_delay_between_testcases()
 
     def run(self) -> TestResult:
         """

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_activation_time.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_activation_time.py
@@ -39,7 +39,7 @@ class CTAMTestFullDeviceUpdateActivationTime(TestCase):
     test_name: str = "CTAM Test Full Device Update Activation Time"
     test_id: str = "F64"
     score_weight: int = 10
-    tags: List[str] = []
+    tags: List[str] = ["L1"]
 
     def __init__(self, group: FWUpdateTestGroupN):
         """

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_activation_time.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_activation_time.py
@@ -40,6 +40,7 @@ class CTAMTestFullDeviceUpdateActivationTime(TestCase):
     test_id: str = "F64"
     score_weight: int = 10
     tags: List[str] = ["L1"]
+    compliance_level: str = "L1"
 
     def __init__(self, group: FWUpdateTestGroupN):
         """

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_activation_time.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_activation_time.py
@@ -129,12 +129,8 @@ class CTAMTestFullDeviceUpdateActivationTime(TestCase):
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():
-            if self.group.fw_update_ifc.ctam_activate_ac(check_time=False):
-                msg = f"{self.test_id} : AC Cycle Passed"
-                self.test_run().add_log(LogSeverity.DEBUG, msg)  
-            else:
-                msg = f"{self.test_id} : AC Cycle Failed"
-                self.test_run().add_log(LogSeverity.DEBUG, msg)
+            self.group.fw_update_ifc.ctam_delay_between_testcases()
+            step1.add_log(LogSeverity.INFO, f"Teardown delay completed.")
 
         # call super teardown last
         super().teardown()

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_activation_with_failed_component.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_activation_with_failed_component.py
@@ -42,6 +42,7 @@ class CTAMTestFullDeviceUpdateActivationWithFailedComponent(TestCase):
     test_id: str = "F56"
     score_weight: int = 10
     tags: List[str] = ["L3"]
+    compliance_level: str = "L3"
 
     def __init__(self, group: FWUpdateTestGroupN):
         """

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_activation_with_failed_component.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_activation_with_failed_component.py
@@ -41,7 +41,7 @@ class CTAMTestFullDeviceUpdateActivationWithFailedComponent(TestCase):
     test_name: str = "CTAM Test Full Device Update Activation With Failed Component"
     test_id: str = "F56"
     score_weight: int = 10
-    tags: List[str] = []
+    tags: List[str] = ["L3"]
 
     def __init__(self, group: FWUpdateTestGroupN):
         """
@@ -149,7 +149,7 @@ class CTAMTestFullDeviceUpdateActivationWithFailedComponent(TestCase):
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():
-            if self.group.fw_update_ifc.ctam_activate_ac():
+            if self.group.fw_update_ifc.ctam_activate_ac(check_time=False):
                 msg = f"{self.test_id} : AC Cycle Passed"
                 self.test_run().add_log(LogSeverity.DEBUG, msg)  
             else:

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_activation_with_failed_component.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_activation_with_failed_component.py
@@ -149,12 +149,8 @@ class CTAMTestFullDeviceUpdateActivationWithFailedComponent(TestCase):
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():
-            if self.group.fw_update_ifc.ctam_activate_ac(check_time=False):
-                msg = f"{self.test_id} : AC Cycle Passed"
-                self.test_run().add_log(LogSeverity.DEBUG, msg)  
-            else:
-                msg = f"{self.test_id} : AC Cycle Failed"
-                self.test_run().add_log(LogSeverity.DEBUG, msg)
+            self.group.fw_update_ifc.ctam_delay_between_testcases()
+            step1.add_log(LogSeverity.INFO, f"Teardown delay completed.")
 
         # call super teardown last
         super().teardown()

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_in_loop.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_in_loop.py
@@ -39,7 +39,7 @@ class CTAMTestFullDeviceUpdateInLoop(TestCase):
     test_name: str = "CTAM Test Full Device Update In Loop"
     test_id: str = "F8"
     score_weight: int = 10
-    tags: List[str] = []
+    tags: List[str] = ["L1"]
 
     def __init__(self, group: FWUpdateTestGroupN):
         """

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_in_loop.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_in_loop.py
@@ -159,12 +159,8 @@ class CTAMTestFullDeviceUpdateInLoop(TestCase):
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():
-            if self.group.fw_update_ifc.ctam_activate_ac(check_time=False):
-                msg = f"{self.test_id} : AC Cycle Passed"
-                self.test_run().add_log(LogSeverity.DEBUG, msg)  
-            else:
-                msg = f"{self.test_id} : AC Cycle Failed"
-                self.test_run().add_log(LogSeverity.DEBUG, msg)
+            self.group.fw_update_ifc.ctam_delay_between_testcases()
+            step1.add_log(LogSeverity.INFO, f"Teardown delay completed.")
 
         # call super teardown last
         super().teardown()

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_in_loop.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_in_loop.py
@@ -159,7 +159,7 @@ class CTAMTestFullDeviceUpdateInLoop(TestCase):
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():
-            if self.group.fw_update_ifc.ctam_activate_ac():
+            if self.group.fw_update_ifc.ctam_activate_ac(check_time=False):
                 msg = f"{self.test_id} : AC Cycle Passed"
                 self.test_run().add_log(LogSeverity.DEBUG, msg)  
             else:

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_in_loop.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_in_loop.py
@@ -40,6 +40,7 @@ class CTAMTestFullDeviceUpdateInLoop(TestCase):
     test_id: str = "F8"
     score_weight: int = 10
     tags: List[str] = ["L1"]
+    compliance_level: str = "L1"
 
     def __init__(self, group: FWUpdateTestGroupN):
         """

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_ping_pong.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_ping_pong.py
@@ -40,6 +40,7 @@ class CTAMTestFullDeviceUpdatePingPong(TestCase):
     test_id: str = "F88"
     score_weight: int = 10
     tags: List[str] = ["Compliance", "L1"]
+    compliance_level: str = "L1"
 
     def __init__(self, group: FWUpdateTestGroupN):
         """

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_ping_pong.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_ping_pong.py
@@ -147,12 +147,8 @@ class CTAMTestFullDeviceUpdatePingPong(TestCase):
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():
-            if self.group.fw_update_ifc.ctam_activate_ac(check_time=False):
-                msg = f"{self.test_id} : AC Cycle Passed"
-                self.test_run().add_log(LogSeverity.DEBUG, msg)  
-            else:
-                msg = f"{self.test_id} : AC Cycle Failed"
-                self.test_run().add_log(LogSeverity.DEBUG, msg)
+            self.group.fw_update_ifc.ctam_delay_between_testcases()
+            step1.add_log(LogSeverity.INFO, f"Teardown delay completed.")
 
         # call super teardown last
         super().teardown()

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_ping_pong.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_ping_pong.py
@@ -39,7 +39,7 @@ class CTAMTestFullDeviceUpdatePingPong(TestCase):
     test_name: str = "CTAM Test Full Device Update Ping Pong"
     test_id: str = "F88"
     score_weight: int = 10
-    tags: List[str] = ["Compliance"]
+    tags: List[str] = ["Compliance", "L1"]
 
     def __init__(self, group: FWUpdateTestGroupN):
         """

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_ping_pong.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_ping_pong.py
@@ -147,7 +147,7 @@ class CTAMTestFullDeviceUpdatePingPong(TestCase):
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():
-            if self.group.fw_update_ifc.ctam_activate_ac():
+            if self.group.fw_update_ifc.ctam_activate_ac(check_time=False):
                 msg = f"{self.test_id} : AC Cycle Passed"
                 self.test_run().add_log(LogSeverity.DEBUG, msg)  
             else:

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_rollback.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_rollback.py
@@ -39,7 +39,7 @@ class CTAMTestFullDeviceUpdateRollback(TestCase):
     test_name: str = "CTAM Test Full Device Update Rollback"
     test_id: str = "F0"
     score_weight: int = 10
-    tags: List[str] = ["Compliance"]
+    tags: List[str] = ["Compliance", "L0"]
 
     def __init__(self, group: FWUpdateTestGroupN):
         """

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_rollback.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_rollback.py
@@ -130,12 +130,8 @@ class CTAMTestFullDeviceUpdateRollback(TestCase):
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():
-            if self.group.fw_update_ifc.ctam_activate_ac(check_time=False):
-                msg = f"{self.test_id} : AC Cycle Passed"
-                self.test_run().add_log(LogSeverity.DEBUG, msg)  
-            else:
-                msg = f"{self.test_id} : AC Cycle Failed"
-                self.test_run().add_log(LogSeverity.DEBUG, msg)
+            self.group.fw_update_ifc.ctam_delay_between_testcases()
+            step1.add_log(LogSeverity.INFO, f"Teardown delay completed.")
 
         # call super teardown last
         super().teardown()

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_rollback.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_rollback.py
@@ -40,6 +40,7 @@ class CTAMTestFullDeviceUpdateRollback(TestCase):
     test_id: str = "F0"
     score_weight: int = 10
     tags: List[str] = ["Compliance", "L0"]
+    compliance_level: str = "L0"
 
     def __init__(self, group: FWUpdateTestGroupN):
         """

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_rollback.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_rollback.py
@@ -130,7 +130,7 @@ class CTAMTestFullDeviceUpdateRollback(TestCase):
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():
-            if self.group.fw_update_ifc.ctam_activate_ac():
+            if self.group.fw_update_ifc.ctam_activate_ac(check_time=False):
                 msg = f"{self.test_id} : AC Cycle Passed"
                 self.test_run().add_log(LogSeverity.DEBUG, msg)  
             else:

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_staging_interruption_with_single_device_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_staging_interruption_with_single_device_update.py
@@ -38,7 +38,7 @@ class CTAMTestFullDeviceUpdateInterruptionWithSingleDeviceUpdate(TestCase):
     test_name: str = "CTAM Test Full Device Update Staging Interruption With Single Device Update"
     test_id: str = "F24"
     score_weight: int = 10
-    tags: List[str] = []
+    tags: List[str] = ["Negative", "L2"]
 
     def __init__(self, group: FWUpdateTestGroupN):
         """

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_staging_time.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_staging_time.py
@@ -58,7 +58,7 @@ class CTAMTestFullDeviceUpdateStagingTime(TestCase):
         # add custom setup here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  setup()...")
         with step1.scope():
-            self.group.fw_update_ifc.ctam_delay_between_testcases()
+            pass
 
     def run(self) -> TestResult:
         """
@@ -128,11 +128,8 @@ class CTAMTestFullDeviceUpdateStagingTime(TestCase):
 
         step3 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...step3")
         with step3.scope():
-            if self.group.fw_update_ifc.ctam_activate_ac(check_time=False):
-                msg = f"{self.test_id} : AC Cycle Passed"
-                self.test_run().add_log(LogSeverity.DEBUG, msg)  
-            else:
-                msg = f"{self.test_id} : AC Cycle Failed"
-                self.test_run().add_log(LogSeverity.DEBUG, msg)
+            self.group.fw_update_ifc.ctam_delay_between_testcases()
+            step1.add_log(LogSeverity.INFO, f"Teardown delay completed.")
+
         # call super teardown last
         super().teardown()

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_staging_time.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_staging_time.py
@@ -58,7 +58,7 @@ class CTAMTestFullDeviceUpdateStagingTime(TestCase):
         # add custom setup here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  setup()...")
         with step1.scope():
-            pass
+            self.group.fw_update_ifc.ctam_delay_between_testcases()
 
     def run(self) -> TestResult:
         """
@@ -128,7 +128,7 @@ class CTAMTestFullDeviceUpdateStagingTime(TestCase):
 
         step3 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...step3")
         with step3.scope():
-            if self.group.fw_update_ifc.ctam_activate_ac():
+            if self.group.fw_update_ifc.ctam_activate_ac(check_time=False):
                 msg = f"{self.test_id} : AC Cycle Passed"
                 self.test_run().add_log(LogSeverity.DEBUG, msg)  
             else:

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_staging_time.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_staging_time.py
@@ -39,7 +39,7 @@ class CTAMTestFullDeviceUpdateStagingTime(TestCase):
     test_name: str = "CTAM Test Full Device Update Staging Time"
     test_id: str = "F63"
     score_weight: int = 10
-    tags: List[str] = []
+    tags: List[str] = ["L1"]
 
     def __init__(self, group: FWUpdateTestGroupN):
         """

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_staging_time.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_staging_time.py
@@ -40,6 +40,7 @@ class CTAMTestFullDeviceUpdateStagingTime(TestCase):
     test_id: str = "F63"
     score_weight: int = 10
     tags: List[str] = ["L1"]
+    compliance_level: str = "L1"
 
     def __init__(self, group: FWUpdateTestGroupN):
         """

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_staging_with_failed_component.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_staging_with_failed_component.py
@@ -132,12 +132,8 @@ class CTAMTestFullDeviceUpdateStagingWithFailedComponent(TestCase):
         
         step2 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...step2")
         with step2.scope():
-            if self.group.fw_update_ifc.ctam_activate_ac(check_time=False):
-                msg = f"{self.test_id} : AC Cycle Passed"
-                self.test_run().add_log(LogSeverity.DEBUG, msg)  
-            else:
-                msg = f"{self.test_id} : AC Cycle Failed"
-                self.test_run().add_log(LogSeverity.DEBUG, msg)
+            self.group.fw_update_ifc.ctam_delay_between_testcases()
+            step1.add_log(LogSeverity.INFO, f"Teardown delay completed.")
 
         # call super teardown last
         super().teardown()

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_staging_with_failed_component.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_staging_with_failed_component.py
@@ -41,7 +41,7 @@ class CTAMTestFullDeviceUpdateStagingWithFailedComponent(TestCase):
     test_name: str = "CTAM Test Full Device Update Staging With Failed Component"
     test_id: str = "F55"
     score_weight: int = 10
-    tags: List[str] = []
+    tags: List[str] = ["L3"]
 
     def __init__(self, group: FWUpdateTestGroupN):
         """
@@ -132,7 +132,7 @@ class CTAMTestFullDeviceUpdateStagingWithFailedComponent(TestCase):
         
         step2 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...step2")
         with step2.scope():
-            if self.group.fw_update_ifc.ctam_activate_ac():
+            if self.group.fw_update_ifc.ctam_activate_ac(check_time=False):
                 msg = f"{self.test_id} : AC Cycle Passed"
                 self.test_run().add_log(LogSeverity.DEBUG, msg)  
             else:

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_staging_with_failed_component.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_staging_with_failed_component.py
@@ -42,6 +42,7 @@ class CTAMTestFullDeviceUpdateStagingWithFailedComponent(TestCase):
     test_id: str = "F55"
     score_weight: int = 10
     tags: List[str] = ["L3"]
+    compliance_level: str = "L3"
 
     def __init__(self, group: FWUpdateTestGroupN):
         """

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_with_older_version.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_with_older_version.py
@@ -59,7 +59,7 @@ class CTAMTestFullDeviceUpdateWithOlderVersion(TestCase):
         # add custom setup here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  setup()...")
         with step1.scope():
-            self.group.fw_update_ifc.ctam_delay_between_testcases()
+            pass
 
     def run(self) -> TestResult:
         """
@@ -142,12 +142,8 @@ class CTAMTestFullDeviceUpdateWithOlderVersion(TestCase):
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():
-            if self.group.fw_update_ifc.ctam_activate_ac(check_time=False):
-                msg = f"{self.test_id} : AC Cycle Passed"
-                self.test_run().add_log(LogSeverity.DEBUG, msg)  
-            else:
-                msg = f"{self.test_id} : AC Cycle Failed"
-                self.test_run().add_log(LogSeverity.DEBUG, msg)
+            self.group.fw_update_ifc.ctam_delay_between_testcases()
+            step1.add_log(LogSeverity.INFO, f"Teardown delay completed.")
 
         # call super teardown last
         super().teardown()

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_with_older_version.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_with_older_version.py
@@ -41,6 +41,7 @@ class CTAMTestFullDeviceUpdateWithOlderVersion(TestCase):
     test_id: str = "F19"
     score_weight: int = 10
     tags: List[str] = ["L3"]
+    compliance_level: str = "L3"
 
     def __init__(self, group: FWUpdateTestGroupN):
         """

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_with_older_version.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_with_older_version.py
@@ -40,7 +40,7 @@ class CTAMTestFullDeviceUpdateWithOlderVersion(TestCase):
     test_name: str = "CTAM Test Full Device Update With Older Version"
     test_id: str = "F19"
     score_weight: int = 10
-    tags: List[str] = []
+    tags: List[str] = ["L3"]
 
     def __init__(self, group: FWUpdateTestGroupN):
         """
@@ -59,7 +59,7 @@ class CTAMTestFullDeviceUpdateWithOlderVersion(TestCase):
         # add custom setup here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  setup()...")
         with step1.scope():
-            pass
+            self.group.fw_update_ifc.ctam_delay_between_testcases()
 
     def run(self) -> TestResult:
         """
@@ -142,7 +142,12 @@ class CTAMTestFullDeviceUpdateWithOlderVersion(TestCase):
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():
-            pass
+            if self.group.fw_update_ifc.ctam_activate_ac(check_time=False):
+                msg = f"{self.test_id} : AC Cycle Passed"
+                self.test_run().add_log(LogSeverity.DEBUG, msg)  
+            else:
+                msg = f"{self.test_id} : AC Cycle Failed"
+                self.test_run().add_log(LogSeverity.DEBUG, msg)
 
         # call super teardown last
         super().teardown()

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_with_self_test.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_with_self_test.py
@@ -49,6 +49,7 @@ class CTAMTestFullDeviceUpdateWithSelfTest(TestCase):
     test_id: str = "F67"
     score_weight: int = 10
     tags: List[str] = ["L3"]
+    compliance_level: str = "L3"
 
     def __init__(self, group: FWUpdateTestGroupN):
         """

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_with_self_test.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_with_self_test.py
@@ -48,7 +48,7 @@ class CTAMTestFullDeviceUpdateWithSelfTest(TestCase):
     test_name: str = "CTAM Test Full Device Update with Self-test Verification"
     test_id: str = "F67"
     score_weight: int = 10
-    tags: List[str] = []
+    tags: List[str] = ["L3"]
 
     def __init__(self, group: FWUpdateTestGroupN):
         """

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_with_self_test.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_with_self_test.py
@@ -119,7 +119,8 @@ class CTAMTestFullDeviceUpdateWithSelfTest(TestCase):
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():
-            pass
+            self.group.fw_update_ifc.ctam_delay_between_testcases()
+            step1.add_log(LogSeverity.INFO, f"Teardown delay completed.")
 
         # call super teardown last
         super().teardown()

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_corrupt_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_corrupt_image_update.py
@@ -41,7 +41,7 @@ class CTAMTestNegativeCorruptImageUpdate(TestCase):
     test_name: str = "CTAM Test Negative Corrupt Image Update"
     test_id: str = "F23"
     score_weight: int = 10
-    tags: List[str] = ["Negative"]
+    tags: List[str] = ["Negative", "L2"]
 
     def __init__(self, group: FWUpdateTestGroupN):
         """

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_corrupt_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_corrupt_image_update.py
@@ -96,7 +96,7 @@ class CTAMTestNegativeCorruptImageUpdate(TestCase):
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope(): 
-            if self.group.fw_update_ifc.ctam_activate_ac():
+            if self.group.fw_update_ifc.ctam_activate_ac(gpu_check=False):
                 msg = f"{self.test_id} : AC Cycle Passed"
                 self.test_run().add_log(LogSeverity.DEBUG, msg)  
             else:

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_corrupt_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_corrupt_image_update.py
@@ -42,6 +42,7 @@ class CTAMTestNegativeCorruptImageUpdate(TestCase):
     test_id: str = "F23"
     score_weight: int = 10
     tags: List[str] = ["Negative", "L2"]
+    compliance_level: str = "L2"
 
     def __init__(self, group: FWUpdateTestGroupN):
         """

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_empty_metadata_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_empty_metadata_image_update.py
@@ -118,14 +118,6 @@ class CTAMTestNegativeEmptyMetadataImageUpdate(TestCase):
                 step1.add_log(LogSeverity.INFO, f"{self.test_id} : Push URI Targets Reset")
             else:
                 step1.add_log(LogSeverity.WARNING, f"{self.test_id} : Push URI Targets Reset - Failed")
-
-        step2 = self.test_run().add_step(f"{self.__class__.__name__}  teardown(), Step2")
-        with step2.scope():
-            if self.group.fw_update_ifc.ctam_activate_ac(gpu_check=False):
-                msg = f"{self.test_id} : AC Cycle Passed"
-                self.test_run().add_log(LogSeverity.DEBUG, msg)  
-            else:
-                msg = f"{self.test_id} : AC Cycle Failed"
-                self.test_run().add_log(LogSeverity.DEBUG, msg)
+        
         # call super teardown last
         super().teardown()

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_empty_metadata_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_empty_metadata_image_update.py
@@ -42,6 +42,7 @@ class CTAMTestNegativeEmptyMetadataImageUpdate(TestCase):
     test_id: str = "F26"
     score_weight: int = 10
     tags: List[str] = ["Negative", "L2"]
+    compliance_level: str = "L2"
 
     def __init__(self, group: FWUpdateTestGroupN):
         """

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_empty_metadata_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_empty_metadata_image_update.py
@@ -41,7 +41,7 @@ class CTAMTestNegativeEmptyMetadataImageUpdate(TestCase):
     test_name: str = "CTAM Test Negative Empty Metadata Image Update"
     test_id: str = "F26"
     score_weight: int = 10
-    tags: List[str] = ["Negative"]
+    tags: List[str] = ["Negative", "L2"]
 
     def __init__(self, group: FWUpdateTestGroupN):
         """

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_empty_metadata_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_empty_metadata_image_update.py
@@ -121,7 +121,7 @@ class CTAMTestNegativeEmptyMetadataImageUpdate(TestCase):
 
         step2 = self.test_run().add_step(f"{self.__class__.__name__}  teardown(), Step2")
         with step2.scope():
-            if self.group.fw_update_ifc.ctam_activate_ac():
+            if self.group.fw_update_ifc.ctam_activate_ac(gpu_check=False):
                 msg = f"{self.test_id} : AC Cycle Passed"
                 self.test_run().add_log(LogSeverity.DEBUG, msg)  
             else:

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_full_device_update_staging_interruption_with_ac_reset.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_full_device_update_staging_interruption_with_ac_reset.py
@@ -3,14 +3,14 @@ Copyright (c) NVIDIA CORPORATION
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 
-:Test Name:		CTAM Test Negative Full Device Update Staging Interruption With Single Device Update
+:Test Name:		CTAM Test Negative Full Device Update Staging Interruption With AC Reset
 :Test ID:		F24
 :Group Name:	fw_update
 :Score Weight:	10
 
 :Description:	Test case of full firmware update in a loop. To verify the ongoing rollback is not affected by 
 :Usage 1:		python ctam.py -w ..\workspace -t F24
-:Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Full Device Update Staging Interruption With Single Device Update"
+:Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Full Device Update Staging Interruption With AC Reset"
 
 """
 from typing import Optional, List
@@ -35,7 +35,7 @@ class CTAMTestFullDeviceUpdateInterruptionWithSingleDeviceUpdate(TestCase):
     :type TestCase:
     """
 
-    test_name: str = "CTAM Test Full Device Update Staging Interruption With Single Device Update"
+    test_name: str = "CTAM Test Negative Full Device Update Staging Interruption With AC Reset"
     test_id: str = "F24"
     score_weight: int = 10
     tags: List[str] = ["Negative", "L2"]

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_full_device_update_staging_interruption_with_ac_reset.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_full_device_update_staging_interruption_with_ac_reset.py
@@ -39,6 +39,7 @@ class CTAMTestFullDeviceUpdateInterruptionWithSingleDeviceUpdate(TestCase):
     test_id: str = "F24"
     score_weight: int = 10
     tags: List[str] = ["Negative", "L2"]
+    compliance_level: str = "L2"
 
     def __init__(self, group: FWUpdateTestGroupN):
         """

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_full_device_update_staging_interruption_with_single_device_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_full_device_update_staging_interruption_with_single_device_update.py
@@ -186,13 +186,5 @@ class CTAMTestFullDeviceUpdateInterruptionWithSingleDeviceUpdate(TestCase):
             else:
                 step1.add_log(LogSeverity.WARNING, f"{self.test_id} : Push URI Targets Reset - Failed")
 
-        step2 = self.test_run().add_step(f"{self.__class__.__name__}  teardown(), Step2")
-        with step2.scope():
-            if self.group.fw_update_ifc.ctam_activate_ac(check_time=False):
-                msg = f"{self.test_id} : AC Cycle Passed"
-                self.test_run().add_log(LogSeverity.DEBUG, msg)  
-            else:
-                msg = f"{self.test_id} : AC Cycle Failed"
-                self.test_run().add_log(LogSeverity.DEBUG, msg)
         # call super teardown last
         super().teardown()

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_full_device_update_staging_interruption_with_single_device_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_full_device_update_staging_interruption_with_single_device_update.py
@@ -3,7 +3,7 @@ Copyright (c) NVIDIA CORPORATION
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 
-:Test Name:		CTAM Test Full Device Update Staging Interruption With Single Device Update
+:Test Name:		CTAM Test Negative Full Device Update Staging Interruption With Single Device Update
 :Test ID:		F24
 :Group Name:	fw_update
 :Score Weight:	10
@@ -188,7 +188,7 @@ class CTAMTestFullDeviceUpdateInterruptionWithSingleDeviceUpdate(TestCase):
 
         step2 = self.test_run().add_step(f"{self.__class__.__name__}  teardown(), Step2")
         with step2.scope():
-            if self.group.fw_update_ifc.ctam_activate_ac():
+            if self.group.fw_update_ifc.ctam_activate_ac(check_time=False):
                 msg = f"{self.test_id} : AC Cycle Passed"
                 self.test_run().add_log(LogSeverity.DEBUG, msg)  
             else:

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_device_uuid_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_device_uuid_image_update.py
@@ -99,7 +99,7 @@ class CTAMTestNegativeInvalidDeviceUUIDImageUpdate(TestCase):
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():
-            if self.group.fw_update_ifc.ctam_activate_ac():
+            if self.group.fw_update_ifc.ctam_activate_ac(gpu_check=False):
                 msg = f"{self.test_id} : AC Cycle Passed"
                 self.test_run().add_log(LogSeverity.DEBUG, msg)  
             else:

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_device_uuid_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_device_uuid_image_update.py
@@ -41,7 +41,7 @@ class CTAMTestNegativeInvalidDeviceUUIDImageUpdate(TestCase):
     test_name: str = "CTAM Test Negative Invalid Device UUID Image Update"
     test_id: str = "F28"
     score_weight: int = 10
-    tags: List[str] = []
+    tags: List[str] = ["Negative", "L2"]
 
     def __init__(self, group: FWUpdateTestGroupN):
         """

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_device_uuid_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_device_uuid_image_update.py
@@ -42,6 +42,7 @@ class CTAMTestNegativeInvalidDeviceUUIDImageUpdate(TestCase):
     test_id: str = "F28"
     score_weight: int = 10
     tags: List[str] = ["Negative", "L2"]
+    compliance_level: str = "L2"
 
     def __init__(self, group: FWUpdateTestGroupN):
         """

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_package_uuid_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_package_uuid_image_update.py
@@ -99,7 +99,7 @@ class CTAMTestNegativeInvalidPackageUUIDImageUpdate(TestCase):
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():
-            if self.group.fw_update_ifc.ctam_activate_ac():
+            if self.group.fw_update_ifc.ctam_activate_ac(gpu_check=False):
                 msg = f"{self.test_id} : AC Cycle Passed"
                 self.test_run().add_log(LogSeverity.DEBUG, msg)  
             else:

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_package_uuid_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_package_uuid_image_update.py
@@ -41,7 +41,7 @@ class CTAMTestNegativeInvalidPackageUUIDImageUpdate(TestCase):
     test_name: str = "CTAM Test Negative Invalid Package UUID Image Update"
     test_id: str = "F27"
     score_weight: int = 10
-    tags: List[str] = ["Negative"]
+    tags: List[str] = ["Negative", "L2"]
 
     def __init__(self, group: FWUpdateTestGroupN):
         """

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_package_uuid_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_package_uuid_image_update.py
@@ -42,6 +42,7 @@ class CTAMTestNegativeInvalidPackageUUIDImageUpdate(TestCase):
     test_id: str = "F27"
     score_weight: int = 10
     tags: List[str] = ["Negative", "L2"]
+    compliance_level: str = "L2"
 
     def __init__(self, group: FWUpdateTestGroupN):
         """

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_signed_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_signed_image_update.py
@@ -100,12 +100,7 @@ class CTAMTestNegativeInvalidSignedImageUpdate(TestCase):
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():
-            if self.group.fw_update_ifc.ctam_activate_ac(gpu_check=False):
-                msg = f"{self.test_id} : AC Cycle Passed"
-                self.test_run().add_log(LogSeverity.DEBUG, msg)  
-            else:
-                msg = f"{self.test_id} : AC Cycle Failed"
-                self.test_run().add_log(LogSeverity.DEBUG, msg)
+            pass
 
         # call super teardown last
         super().teardown()

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_signed_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_signed_image_update.py
@@ -100,7 +100,7 @@ class CTAMTestNegativeInvalidSignedImageUpdate(TestCase):
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():
-            if self.group.fw_update_ifc.ctam_activate_ac():
+            if self.group.fw_update_ifc.ctam_activate_ac(gpu_check=False):
                 msg = f"{self.test_id} : AC Cycle Passed"
                 self.test_run().add_log(LogSeverity.DEBUG, msg)  
             else:

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_signed_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_signed_image_update.py
@@ -42,7 +42,7 @@ class CTAMTestNegativeInvalidSignedImageUpdate(TestCase):
     test_name: str = "CTAM Test Negative Invalid Signed Image Update"
     test_id: str = "F22"
     score_weight: int = 10
-    tags: List[str] = ["Negative"]
+    tags: List[str] = ["Negative", "L2"]
 
     def __init__(self, group: FWUpdateTestGroupN):
         """

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_signed_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_signed_image_update.py
@@ -43,6 +43,7 @@ class CTAMTestNegativeInvalidSignedImageUpdate(TestCase):
     test_id: str = "F22"
     score_weight: int = 10
     tags: List[str] = ["Negative", "L2"]
+    compliance_level: str = "L2"
 
     def __init__(self, group: FWUpdateTestGroupN):
         """

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_large_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_large_image_update.py
@@ -40,7 +40,7 @@ class CTAMTestNegativeLargeImageUpdate(TestCase):
     test_name: str = "CTAM Test Negative Large Image Update"
     test_id: str = "F25"
     score_weight: int = 10
-    tags: List[str] = ["Negative"]
+    tags: List[str] = ["Negative", "L2"]
 
     def __init__(self, group: FWUpdateTestGroupN):
         """

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_large_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_large_image_update.py
@@ -41,6 +41,7 @@ class CTAMTestNegativeLargeImageUpdate(TestCase):
     test_id: str = "F25"
     score_weight: int = 10
     tags: List[str] = ["Negative", "L2"]
+    compliance_level: str = "L2"
 
     def __init__(self, group: FWUpdateTestGroupN):
         """

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_large_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_large_image_update.py
@@ -96,7 +96,7 @@ class CTAMTestNegativeLargeImageUpdate(TestCase):
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():
-            if self.group.fw_update_ifc.ctam_activate_ac():
+            if self.group.fw_update_ifc.ctam_activate_ac(gpu_check=False):
                 msg = f"{self.test_id} : AC Cycle Passed"
                 self.test_run().add_log(LogSeverity.DEBUG, msg)  
             else:

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_single_fw_update_staging_interruption_with_ac_reset.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_single_fw_update_staging_interruption_with_ac_reset.py
@@ -130,12 +130,7 @@ class CTAMTestSingleFWUpdateStagingInterruptionWithACReset(TestCase):
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():
-            if self.group.fw_update_ifc.ctam_activate_ac(gpu_check=False):
-                msg = f"{self.test_id} : AC Cycle Passed"
-                self.test_run().add_log(LogSeverity.DEBUG, msg)  
-            else:
-                msg = f"{self.test_id} : AC Cycle Failed"
-                self.test_run().add_log(LogSeverity.DEBUG, msg)
+            pass
 
         # call super teardown last
         super().teardown()

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_single_fw_update_staging_interruption_with_ac_reset.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_single_fw_update_staging_interruption_with_ac_reset.py
@@ -3,7 +3,7 @@ Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 
-:Test Name:		CTAM Test Single FW update staging interruption with AC reset
+:Test Name:		CTAM Test Negative Single FW update staging interruption with AC reset
 :Test ID:		F62
 :Group Name:	fw_update
 :Score Weight:	10
@@ -41,7 +41,7 @@ class CTAMTestSingleFWUpdateStagingInterruptionWithACReset(TestCase):
     test_name: str = "CTAM Test Single FW update staging interruption with AC reset"
     test_id: str = "F62"
     score_weight: int = 10
-    tags: List[str] = ["L2"]
+    tags: List[str] = ["Negative", "L3"]
 
     def __init__(self, group: FWUpdateTestGroupN):
         """
@@ -130,7 +130,12 @@ class CTAMTestSingleFWUpdateStagingInterruptionWithACReset(TestCase):
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():
-            pass
+            if self.group.fw_update_ifc.ctam_activate_ac(gpu_check=False):
+                msg = f"{self.test_id} : AC Cycle Passed"
+                self.test_run().add_log(LogSeverity.DEBUG, msg)  
+            else:
+                msg = f"{self.test_id} : AC Cycle Failed"
+                self.test_run().add_log(LogSeverity.DEBUG, msg)
 
         # call super teardown last
         super().teardown()

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_single_fw_update_staging_interruption_with_ac_reset.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_single_fw_update_staging_interruption_with_ac_reset.py
@@ -42,6 +42,7 @@ class CTAMTestSingleFWUpdateStagingInterruptionWithACReset(TestCase):
     test_id: str = "F62"
     score_weight: int = 10
     tags: List[str] = ["Negative", "L3"]
+    compliance_level: str = "L3"
 
     def __init__(self, group: FWUpdateTestGroupN):
         """

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_unsigned_bundle_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_unsigned_bundle_update.py
@@ -42,7 +42,8 @@ class CTAMTestNegativeUnsignedBundleUpdate(TestCase):
     test_name: str = "CTAM Test Negative Unsigned Bundle Update"
     test_id: str = "F90"
     score_weight: int = 10
-    tags: List[str] = ["L3", "Negative"]
+    tags: List[str] = ["Negative", "L3"]
+    compliance_level: str = "L3"
 
     def __init__(self, group: FWUpdateTestGroupN):
         """

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_unsigned_bundle_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_unsigned_bundle_update.py
@@ -42,7 +42,7 @@ class CTAMTestNegativeUnsignedBundleUpdate(TestCase):
     test_name: str = "CTAM Test Negative Unsigned Bundle Update"
     test_id: str = "F90"
     score_weight: int = 10
-    tags: List[str] = ["Negative"]
+    tags: List[str] = ["L3", "Negative"]
 
     def __init__(self, group: FWUpdateTestGroupN):
         """
@@ -98,7 +98,7 @@ class CTAMTestNegativeUnsignedBundleUpdate(TestCase):
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():
-            if self.group.fw_update_ifc.ctam_activate_ac():
+            if self.group.fw_update_ifc.ctam_activate_ac(gpu_check=False):
                 msg = f"{self.test_id} : AC Cycle Passed"
                 self.test_run().add_log(LogSeverity.DEBUG, msg)  
             else:

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_unsigned_component_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_unsigned_component_image_update.py
@@ -97,12 +97,7 @@ class CTAMTestNegativeUnsignedImageUpdate(TestCase):
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():
-            if self.group.fw_update_ifc.ctam_activate_ac(gpu_check=False):
-                msg = f"{self.test_id} : AC Cycle Passed"
-                self.test_run().add_log(LogSeverity.DEBUG, msg)  
-            else:
-                msg = f"{self.test_id} : AC Cycle Failed"
-                self.test_run().add_log(LogSeverity.DEBUG, msg)
+            pass
 
         # call super teardown last
         super().teardown()

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_unsigned_component_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_unsigned_component_image_update.py
@@ -42,6 +42,7 @@ class CTAMTestNegativeUnsignedImageUpdate(TestCase):
     test_id: str = "F18"
     score_weight: int = 10
     tags: List[str] = ["Negative", "L2"]
+    compliance_level: str = "L2"
 
     def __init__(self, group: FWUpdateTestGroupN):
         """

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_unsigned_component_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_unsigned_component_image_update.py
@@ -97,7 +97,7 @@ class CTAMTestNegativeUnsignedImageUpdate(TestCase):
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():
-            if self.group.fw_update_ifc.ctam_activate_ac():
+            if self.group.fw_update_ifc.ctam_activate_ac(gpu_check=False):
                 msg = f"{self.test_id} : AC Cycle Passed"
                 self.test_run().add_log(LogSeverity.DEBUG, msg)  
             else:

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_unsigned_component_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_unsigned_component_image_update.py
@@ -41,7 +41,7 @@ class CTAMTestNegativeUnsignedImageUpdate(TestCase):
     test_name: str = "CTAM Test Negative Unsigned Image Update"
     test_id: str = "F18"
     score_weight: int = 10
-    tags: List[str] = ["Negative"]
+    tags: List[str] = ["Negative", "L2"]
 
     def __init__(self, group: FWUpdateTestGroupN):
         """

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_update_with_illegal_targets.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_update_with_illegal_targets.py
@@ -41,6 +41,7 @@ class CTAMTestNegativeUpdateWithIllegalTargets(TestCase):
     test_id: str = "F32"
     score_weight: int = 10
     tags: List[str] = ["Negative", "L2"]
+    compliance_level: str = "L2"
 
     def __init__(self, group: FWUpdateTestGroupN):
         """

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_update_with_illegal_targets.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_update_with_illegal_targets.py
@@ -148,12 +148,7 @@ class CTAMTestNegativeUpdateWithIllegalTargets(TestCase):
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():
-            if self.group.fw_update_ifc.ctam_activate_ac(gpu_check=False):
-                msg = f"{self.test_id} : AC Cycle Passed"
-                self.test_run().add_log(LogSeverity.DEBUG, msg)  
-            else:
-                msg = f"{self.test_id} : AC Cycle Failed"
-                self.test_run().add_log(LogSeverity.DEBUG, msg)
+            pass
 
         # call super teardown last
         super().teardown()

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_update_with_illegal_targets.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_update_with_illegal_targets.py
@@ -40,7 +40,7 @@ class CTAMTestNegativeUpdateWithIllegalTargets(TestCase):
     test_name: str = "CTAM Test Negative Update with illegal targets"
     test_id: str = "F32"
     score_weight: int = 10
-    tags: List[str] = ["Negative"]
+    tags: List[str] = ["Negative", "L2"]
 
     def __init__(self, group: FWUpdateTestGroupN):
         """

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_update_with_illegal_targets.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_update_with_illegal_targets.py
@@ -148,7 +148,7 @@ class CTAMTestNegativeUpdateWithIllegalTargets(TestCase):
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():
-            if self.group.fw_update_ifc.ctam_activate_ac():
+            if self.group.fw_update_ifc.ctam_activate_ac(gpu_check=False):
                 msg = f"{self.test_id} : AC Cycle Passed"
                 self.test_run().add_log(LogSeverity.DEBUG, msg)  
             else:

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_single_device_update_ping_pong.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_single_device_update_ping_pong.py
@@ -138,12 +138,8 @@ class CTAMTestSingleDeviceUpdatePingPong(TestCase):
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():
-            if self.group.fw_update_ifc.ctam_activate_ac(gpu_check=False):
-                msg = f"{self.test_id} : AC Cycle Passed"
-                self.test_run().add_log(LogSeverity.DEBUG, msg)  
-            else:
-                msg = f"{self.test_id} : AC Cycle Failed"
-                self.test_run().add_log(LogSeverity.DEBUG, msg)
+            self.group.fw_update_ifc.ctam_delay_between_testcases()
+            step1.add_log(LogSeverity.INFO, f"Teardown delay completed.")
 
         # call super teardown last
         super().teardown()

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_single_device_update_ping_pong.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_single_device_update_ping_pong.py
@@ -40,7 +40,7 @@ class CTAMTestSingleDeviceUpdatePingPong(TestCase):
     test_name: str = "CTAM Test Single Device Update Ping Pong"
     test_id: str = "F89"
     score_weight: int = 10
-    tags: List[str] = ["Single"]
+    tags: List[str] = ["L1"]
 
     def __init__(self, group: FWUpdateTestGroupN):
         """

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_single_device_update_ping_pong.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_single_device_update_ping_pong.py
@@ -40,7 +40,7 @@ class CTAMTestSingleDeviceUpdatePingPong(TestCase):
     test_name: str = "CTAM Test Single Device Update Ping Pong"
     test_id: str = "F89"
     score_weight: int = 10
-    tags: List[str] = ["L1"]
+    tags: List[str] = ["L3"]
 
     def __init__(self, group: FWUpdateTestGroupN):
         """
@@ -138,7 +138,12 @@ class CTAMTestSingleDeviceUpdatePingPong(TestCase):
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():
-            pass
+            if self.group.fw_update_ifc.ctam_activate_ac(gpu_check=False):
+                msg = f"{self.test_id} : AC Cycle Passed"
+                self.test_run().add_log(LogSeverity.DEBUG, msg)  
+            else:
+                msg = f"{self.test_id} : AC Cycle Failed"
+                self.test_run().add_log(LogSeverity.DEBUG, msg)
 
         # call super teardown last
         super().teardown()

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_single_device_update_ping_pong.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_single_device_update_ping_pong.py
@@ -41,6 +41,7 @@ class CTAMTestSingleDeviceUpdatePingPong(TestCase):
     test_id: str = "F89"
     score_weight: int = 10
     tags: List[str] = ["L3"]
+    compliance_level: str = "L3"
 
     def __init__(self, group: FWUpdateTestGroupN):
         """

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_single_fw_update_staging_interruption_with_ac_reset.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_single_fw_update_staging_interruption_with_ac_reset.py
@@ -41,7 +41,7 @@ class CTAMTestSingleFWUpdateStagingInterruptionWithACReset(TestCase):
     test_name: str = "CTAM Test Single FW update staging interruption with AC reset"
     test_id: str = "F62"
     score_weight: int = 10
-    tags: List[str] = []
+    tags: List[str] = ["L2"]
 
     def __init__(self, group: FWUpdateTestGroupN):
         """

--- a/ctam/tests/fw_update/fw_update_group_N_1/_fw_update_group_N_1.py
+++ b/ctam/tests/fw_update/fw_update_group_N_1/_fw_update_group_N_1.py
@@ -20,6 +20,7 @@ class FWUpdateTestGroupNMinus1(TestGroup):
 
     tags: List[str] = []
     group_id : str = "GFW2"
+    domain_name: str = "FWUpdate"
     # exclude_tags: List[str] = []
 
     def __init__(self):

--- a/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_full_device_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_full_device_update.py
@@ -129,7 +129,7 @@ class CTAMTestFullDeviceUpdate(TestCase):
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():
-            if self.group.fw_update_ifc.ctam_activate_ac():
+            if self.group.fw_update_ifc.ctam_activate_ac(gpu_check=False):
                 msg = f"{self.test_id} : AC Cycle Passed"
                 self.test_run().add_log(LogSeverity.DEBUG, msg)  
             else:

--- a/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_full_device_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_full_device_update.py
@@ -129,12 +129,8 @@ class CTAMTestFullDeviceUpdate(TestCase):
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():
-            if self.group.fw_update_ifc.ctam_activate_ac(gpu_check=False):
-                msg = f"{self.test_id} : AC Cycle Passed"
-                self.test_run().add_log(LogSeverity.DEBUG, msg)  
-            else:
-                msg = f"{self.test_id} : AC Cycle Failed"
-                self.test_run().add_log(LogSeverity.DEBUG, msg)
+            self.group.fw_update_ifc.ctam_delay_between_testcases()
+            step1.add_log(LogSeverity.INFO, f"Teardown delay completed.")
 
         # call super teardown last
         super().teardown()

--- a/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_full_device_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_full_device_update.py
@@ -40,6 +40,7 @@ class CTAMTestFullDeviceUpdate(TestCase):
     test_id: str = "F1"
     score_weight: int = 10
     tags: List[str] = ["Compliance", "L0"]
+    compliance_level: str = "L0"
 
     def __init__(self, group: FWUpdateTestGroupNMinus1):
         """

--- a/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_full_device_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_full_device_update.py
@@ -39,7 +39,7 @@ class CTAMTestFullDeviceUpdate(TestCase):
     test_name: str = "CTAM Test Full Device Update"
     test_id: str = "F1"
     score_weight: int = 10
-    tags: List[str] = ["Compliance"]
+    tags: List[str] = ["Compliance", "L0"]
 
     def __init__(self, group: FWUpdateTestGroupNMinus1):
         """

--- a/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_install_same_image_two_times.py
+++ b/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_install_same_image_two_times.py
@@ -140,7 +140,7 @@ class CTAMTestInstallSameImageTwoTimes(TestCase):
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():
-            if self.group.fw_update_ifc.ctam_activate_ac():
+            if self.group.fw_update_ifc.ctam_activate_ac(gpu_check=False):
                 msg = f"{self.test_id} : AC Cycle Passed"
                 self.test_run().add_log(LogSeverity.DEBUG, msg)  
             else:

--- a/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_install_same_image_two_times.py
+++ b/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_install_same_image_two_times.py
@@ -43,6 +43,7 @@ class CTAMTestInstallSameImageTwoTimes(TestCase):
     test_id: str = "F16"
     score_weight: int = 10
     tags: List[str] = ["L1"]
+    compliance_level: str = "L1"
 
     def __init__(self, group: FWUpdateTestGroupNMinus1):
         """

--- a/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_install_same_image_two_times.py
+++ b/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_install_same_image_two_times.py
@@ -61,7 +61,7 @@ class CTAMTestInstallSameImageTwoTimes(TestCase):
         # add custom setup here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  setup()...")
         with step1.scope():
-            self.group.fw_update_ifc.ctam_delay_between_testcases()
+            pass
 
     def run(self) -> TestResult:
         """
@@ -140,12 +140,8 @@ class CTAMTestInstallSameImageTwoTimes(TestCase):
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():
-            if self.group.fw_update_ifc.ctam_activate_ac(gpu_check=False):
-                msg = f"{self.test_id} : AC Cycle Passed"
-                self.test_run().add_log(LogSeverity.DEBUG, msg)  
-            else:
-                msg = f"{self.test_id} : AC Cycle Failed"
-                self.test_run().add_log(LogSeverity.DEBUG, msg)
+            self.group.fw_update_ifc.ctam_delay_between_testcases()
+            step1.add_log(LogSeverity.INFO, f"Teardown delay completed.")
 
         # call super teardown last
         super().teardown()

--- a/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_install_same_image_two_times.py
+++ b/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_install_same_image_two_times.py
@@ -61,7 +61,7 @@ class CTAMTestInstallSameImageTwoTimes(TestCase):
         # add custom setup here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  setup()...")
         with step1.scope():
-            pass
+            self.group.fw_update_ifc.ctam_delay_between_testcases()
 
     def run(self) -> TestResult:
         """

--- a/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_install_same_image_two_times.py
+++ b/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_install_same_image_two_times.py
@@ -42,7 +42,7 @@ class CTAMTestInstallSameImageTwoTimes(TestCase):
     test_name: str = "CTAM Test Install Same Image Two Times"
     test_id: str = "F16"
     score_weight: int = 10
-    tags: List[str] = []
+    tags: List[str] = ["L1"]
 
     def __init__(self, group: FWUpdateTestGroupNMinus1):
         """

--- a/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_single_device_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_single_device_update.py
@@ -158,12 +158,8 @@ class CTAMTestSingleDeviceUpdate(TestCase):
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():
-            if self.group.fw_update_ifc.ctam_activate_ac(gpu_check=False):
-                msg = f"{self.test_id} : AC Cycle Passed"
-                self.test_run().add_log(LogSeverity.DEBUG, msg)  
-            else:
-                msg = f"{self.test_id} : AC Cycle Failed"
-                self.test_run().add_log(LogSeverity.DEBUG, msg)
+            self.group.fw_update_ifc.ctam_delay_between_testcases()
+            step1.add_log(LogSeverity.INFO, f"Teardown delay completed.")
 
         # call super teardown last
         super().teardown()

--- a/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_single_device_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_single_device_update.py
@@ -41,6 +41,7 @@ class CTAMTestSingleDeviceUpdate(TestCase):
     test_id: str = "F4"
     score_weight: int = 10
     tags: List[str] = ["L3"]
+    compliance_level: str = "L3"
 
     def __init__(self, group: FWUpdateTestGroupNMinus1):
         """

--- a/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_single_device_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_single_device_update.py
@@ -40,7 +40,7 @@ class CTAMTestSingleDeviceUpdate(TestCase):
     test_name: str = "CTAM Test Single Device Update"
     test_id: str = "F4"
     score_weight: int = 10
-    tags: List[str] = ["Single"]
+    tags: List[str] = ["L1"]
 
     def __init__(self, group: FWUpdateTestGroupNMinus1):
         """

--- a/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_single_device_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_single_device_update.py
@@ -40,7 +40,7 @@ class CTAMTestSingleDeviceUpdate(TestCase):
     test_name: str = "CTAM Test Single Device Update"
     test_id: str = "F4"
     score_weight: int = 10
-    tags: List[str] = ["L1"]
+    tags: List[str] = ["L3"]
 
     def __init__(self, group: FWUpdateTestGroupNMinus1):
         """
@@ -158,7 +158,12 @@ class CTAMTestSingleDeviceUpdate(TestCase):
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():
-            pass
+            if self.group.fw_update_ifc.ctam_activate_ac(gpu_check=False):
+                msg = f"{self.test_id} : AC Cycle Passed"
+                self.test_run().add_log(LogSeverity.DEBUG, msg)  
+            else:
+                msg = f"{self.test_id} : AC Cycle Failed"
+                self.test_run().add_log(LogSeverity.DEBUG, msg)
 
         # call super teardown last
         super().teardown()

--- a/ctam/tests/health_check/basic_health_check_group/basic_health_check_test_group.py
+++ b/ctam/tests/health_check/basic_health_check_group/basic_health_check_test_group.py
@@ -20,6 +20,7 @@ class BasicHealthCheckTestGroup(TestGroup):
 
     tags: List[str] = []
     group_id : str = "GH1"
+    domain_name: str = "HealthCheck"
     # exclude_tags: List[str] = []
 
     def __init__(self):

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_logservice_dump_uri_list_read.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_logservice_dump_uri_list_read.py
@@ -40,6 +40,7 @@ class CTAMTestLogServiceDumpURIListRead(TestCase):
     test_id: str = "H97"
     score_weight: int = 10
     tags: List[str] = []
+    compliance_level: str =""
 
     def __init__(self, group: BasicHealthCheckTestGroup):
         """

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_logservice_uri_list_read.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_logservice_uri_list_read.py
@@ -41,6 +41,7 @@ class CTAMTestLogServicesURIListRead(TestCase):
     test_id: str = "H99"
     score_weight: int = 10
     tags: List[str] = ["HCheck"]
+    compliance_level: str =""
 
     def __init__(self, group: BasicHealthCheckTestGroup):
         """

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_event_service.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_event_service.py
@@ -40,6 +40,7 @@ class CTAMTestRedfishEventService(TestCase):
     test_id: str = "H8"
     score_weight: int = 10
     tags: List[str] = ["HCheck"]
+    compliance_level: str =""
 
     # exclude_tags: List[str] = ["NotCheck"]
 

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_event_service_create_subscription.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_event_service_create_subscription.py
@@ -40,6 +40,7 @@ class CTAMTestRedfishEventServiceCreateSubscription(TestCase):
     test_id: str = "H83"
     score_weight: int = 10
     tags: List[str] = ["HCheck"]
+    compliance_level: str =""
 
     # exclude_tags: List[str] = ["NotCheck"]
 

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_event_service_delete_subscription.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_event_service_delete_subscription.py
@@ -40,6 +40,7 @@ class CTAMTestRedfishEventServiceDeleteSubscription(TestCase):
     test_id: str = "H81"
     score_weight: int = 10
     tags: List[str] = ["HCheck"]
+    compliance_level: str =""
 
     # exclude_tags: List[str] = ["NotCheck"]
 

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_event_service_list_subscription.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_event_service_list_subscription.py
@@ -40,6 +40,7 @@ class CTAMTestRedfishEventServiceSubscription(TestCase):
     test_id: str = "H80"
     score_weight: int = 10
     tags: List[str] = ["HCheck"]
+    compliance_level: str =""
 
     # exclude_tags: List[str] = ["NotCheck"]
 

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_firmware_inventory_collection.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_firmware_inventory_collection.py
@@ -40,6 +40,7 @@ class CTAMTestRedfishFirmwareInventoryCollection(TestCase):
     test_id: str = "H5"
     score_weight: int = 10
     tags: List[str] = ["HCheck"]
+    compliance_level: str =""
 
     # exclude_tags: List[str] = ["NotCheck"]
 

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_firmware_inventory_expanded_collection.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_firmware_inventory_expanded_collection.py
@@ -40,6 +40,7 @@ class CTAMTestRedfishFirmwareInventoryExpandedCollection(TestCase):
     test_id: str = "H6"
     score_weight: int = 10
     tags: List[str] = ["HCheck"]
+    compliance_level: str =""
 
     # exclude_tags: List[str] = ["NotCheck"]
 

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_processors_expanded_collection.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_processors_expanded_collection.py
@@ -40,6 +40,7 @@ class CTAMTestRedfishProcessorExpandedCollection(TestCase):
     test_id: str = "H51"
     score_weight: int = 10
     tags: List[str] = ["HCheck"]
+    compliance_level: str =""
 
     # exclude_tags: List[str] = ["NotCheck"]
 

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_software_inventory_collection.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_software_inventory_collection.py
@@ -41,6 +41,7 @@ class CTAMTestRedfishSoftwareInventoryCollection(TestCase):
     test_id: str = "H9"
     score_weight: int = 10
     tags: List[str] = ["HCheck"]
+    compliance_level: str =""
 
     # exclude_tags: List[str] = ["NotCheck"]
 

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_software_inventory_expanded_collection.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_software_inventory_expanded_collection.py
@@ -40,6 +40,7 @@ class CTAMTestRedfishSoftwareInventoryExpandedCollection(TestCase):
     test_id: str = "H11"
     score_weight: int = 10
     tags: List[str] = ["HCheck"]
+    compliance_level: str =""
 
     # exclude_tags: List[str] = ["NotCheck"]
 

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_task_service.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_task_service.py
@@ -40,6 +40,7 @@ class CTAMTestRedfishTaskService(TestCase):
     test_id: str = "H10"
     score_weight: int = 10
     tags: List[str] = ["HCheck"]
+    compliance_level: str =""
 
     # exclude_tags: List[str] = ["NotCheck"]
 

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_telemetry_service.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_telemetry_service.py
@@ -40,6 +40,7 @@ class CTAMTestRedfishTelemetryService(TestCase):
     test_id: str = "H7"
     score_weight: int = 10
     tags: List[str] = ["HCheck"]
+    compliance_level: str =""
 
     # exclude_tags: List[str] = ["NotCheck"]
 

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_update_service.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_update_service.py
@@ -40,6 +40,7 @@ class CTAMTestRedfishUpdateService(TestCase):
     test_id: str = "H4"
     score_weight: int = 10
     tags: List[str] = ["HCheck"]
+    compliance_level: str =""
 
     # exclude_tags: List[str] = ["NotCheck"]
 

--- a/ctam/tests/health_check/long_health_check_group/ctam_test_ac_cycles_in_loop.py
+++ b/ctam/tests/health_check/long_health_check_group/ctam_test_ac_cycles_in_loop.py
@@ -66,7 +66,7 @@ class CTAMTestAcCyclesInLoop(TestCase):
         with step1.scope():
             for i in range(loops):
                 if result:
-                    if self.group.health_check_ifc.ctam_activate_ac():
+                    if self.group.health_check_ifc.ctam_activate_ac(gpu_check=False):
                         msg = f"{self.test_id} : AC Cycle Passed Loop {i}"
                         self.test_run().add_log(LogSeverity.DEBUG, msg)  
                     else:

--- a/ctam/tests/health_check/long_health_check_group/ctam_test_ac_cycles_in_loop.py
+++ b/ctam/tests/health_check/long_health_check_group/ctam_test_ac_cycles_in_loop.py
@@ -38,6 +38,7 @@ class CTAMTestAcCyclesInLoop(TestCase):
     test_id: str = 'H100'
     score_weight:int = 10
     tags: List[str] = []
+    compliance_level: str = ""
 
     def __init__(self, group: LongHealthCheckTestGroup):
         """

--- a/ctam/tests/health_check/long_health_check_group/ctam_test_logservice_dump_clearlog.py
+++ b/ctam/tests/health_check/long_health_check_group/ctam_test_logservice_dump_clearlog.py
@@ -38,6 +38,7 @@ class CTAMTestLogserviceDumpClearlog(TestCase):
     test_id: str = 'H96'
     score_weight:int = 10
     tags: List[str] = []
+    compliance_level: str =""
 
     def __init__(self, group: LongHealthCheckTestGroup):
         """

--- a/ctam/tests/health_check/long_health_check_group/ctam_verify_self_test_report.py
+++ b/ctam/tests/health_check/long_health_check_group/ctam_verify_self_test_report.py
@@ -40,6 +40,7 @@ class CTAMVerifySelfTestReport(TestCase):
     test_id: str = "H50"
     score_weight: int = 10
     tags: List[str] = ["HCheck"]
+    compliance_level: str =""
 
     def __init__(self, group: LongHealthCheckTestGroup):
         """

--- a/ctam/tests/health_check/long_health_check_group/long_health_check_test_group.py
+++ b/ctam/tests/health_check/long_health_check_group/long_health_check_test_group.py
@@ -20,6 +20,7 @@ class LongHealthCheckTestGroup(TestGroup):
 
     tags: List[str] = []
     group_id : str = "GH2"
+    domain_name: str = "HealthCheck"
     # exclude_tags: List[str] = []
 
     def __init__(self):

--- a/ctam/tests/manual_override/manual_override_test_group.py
+++ b/ctam/tests/manual_override/manual_override_test_group.py
@@ -21,6 +21,7 @@ class ManualOverrideTestGroup(TestGroup):
 
     tags: List[str] = []
     group_id : str = "GM1"
+    domain_name: str = "Manual"
 
     def __init__(self):
         """

--- a/ctam/tests/ras/basic_ras_test_group.py
+++ b/ctam/tests/ras/basic_ras_test_group.py
@@ -20,6 +20,7 @@ class BasicRasTestGroup(TestGroup):
 
     tags: List[str] = []
     group_id : str = "GR1"
+    domain_name: str = "Ras"
     # exclude_tags: List[str] = []
 
     def __init__(self):

--- a/ctam/tests/ras/ctam_test_collect_crashdump_manager.py
+++ b/ctam/tests/ras/ctam_test_collect_crashdump_manager.py
@@ -40,6 +40,7 @@ class CTAMTestCollectCrashdumpManager(TestCase):
     test_id: str = "R2"
     score_weight: int = 10
     tags: List[str] = []
+    compliance_level: str =""
 
     # exclude_tags: List[str] = ["NotCheck"]
 

--- a/ctam/tests/ras/ctam_test_collect_crashdump_oem_selftest.py
+++ b/ctam/tests/ras/ctam_test_collect_crashdump_oem_selftest.py
@@ -40,6 +40,7 @@ class CTAMTestCollectCrashdumpOEMSelfTest(TestCase):
     test_id: str = "R3"
     score_weight: int = 10
     tags: List[str] = []
+    compliance_level: str =""
 
     # exclude_tags: List[str] = ["NotCheck"]
 

--- a/ctam/tests/ras/ctam_test_discover_crashdump.py
+++ b/ctam/tests/ras/ctam_test_discover_crashdump.py
@@ -45,6 +45,7 @@ class CTAMTestDiscoverCrashdump(TestCase):
     test_id: str = "R1"
     score_weight: int = 10
     tags: List[str] = []
+    compliance_level: str =""
 
     # exclude_tags: List[str] = ["NotCheck"]
 

--- a/ctam/tests/telemetry/basic_telemetry_group/basic_telemetry_group.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/basic_telemetry_group.py
@@ -20,6 +20,7 @@ class BasicTelemetryTestGroup(TestGroup):
 
     tags: List[str] = []
     group_id : str = "GT1"
+    domain_name: str = "Telemetry"
     # exclude_tags: List[str] = []
 
     def __init__(self):

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_redfish_service_validator.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_redfish_service_validator.py
@@ -76,6 +76,7 @@ class CTAMTestServiceValidator(TestCase):
         with step2.scope():
             # uri = self.dut().uri_builder.format_uri(redfish_str="{BaseURI}/Chassis",
             #                                     component_type="GPU")
+            print("#####")
             self.dut().validate_redfish_service(file_name="RedfishServiceValidator", 
                                         uri="/redfish/v1/Chassis",
                                         depth="Single")

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_redfish_service_validator.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_redfish_service_validator.py
@@ -76,7 +76,6 @@ class CTAMTestServiceValidator(TestCase):
         with step2.scope():
             # uri = self.dut().uri_builder.format_uri(redfish_str="{BaseURI}/Chassis",
             #                                     component_type="GPU")
-            print("#####")
             self.dut().validate_redfish_service(file_name="RedfishServiceValidator", 
                                         uri="/redfish/v1/Chassis",
                                         depth="Single")

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_redfish_service_validator.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_redfish_service_validator.py
@@ -3,19 +3,20 @@ Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 
-:Test Name:		CTAM Test Collect Crashdump Manager
-:Test ID:		R2
-:Group Name:	ras
+:Test Name:		CTAM Test Service Validator
+:Test ID:		T0
+:Group Name:	Telemetry
 :Score Weight:	10
 
-:Description:	Placeholder only. Post CollectDiagnisticData for '\redfish\v1\Managers\{Manager}\LogService\EventLog with DiagnosticDataType = Manager
+:Description:	It will validate all of the available URIs.
 
-:Usage 1:		python ctam.py -w ..\workspace -t R2
-:Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Collect Crashdump Manager"
+:Usage 1:		python ctam.py -w ..\workspace -t T0
+:Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Service Validator"
 
 """
 from typing import Optional, List
 from tests.test_case import TestCase
+import os
 from ocptv.output import (
     DiagnosisType,
     LogSeverity,
@@ -26,11 +27,10 @@ from ocptv.output import (
 from tests.telemetry.basic_telemetry_group.basic_telemetry_group import (
     BasicTelemetryTestGroup,
 )
-
+from utils.ctam_utils import GitUtils
 
 class CTAMTestServiceValidator(TestCase):
     """
-    Post CollectDiagnisticData for '\redfish\v1\Managers\{Manager}\LogService\EventLog with DiagnosticDataType = Manager
 
     :param TestCase: super class for all test cases
     :type TestCase:
@@ -40,6 +40,7 @@ class CTAMTestServiceValidator(TestCase):
     test_id: str = "T0"
     score_weight: int = 10
     tags: List[str] = []
+    compliance_level: str = ""
 
     # exclude_tags: List[str] = ["NotCheck"]
 
@@ -67,21 +68,31 @@ class CTAMTestServiceValidator(TestCase):
         actual test verification
         """
         result = True
+        git = GitUtils()
         step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
+        repo_path = "RedfishServiceValidator"
         with step1.scope():
-            self.dut().clone_repo(repo_url="https://github.com/DMTF/Redfish-Service-Validator.git",
-                                  repo_dir="RedfishServiceValidator")
+            result = git.clone_repo(repo_url="https://github.com/DMTF/Redfish-Service-Validator.git",
+                                  repo_path="RedfishServiceValidator")
 
-        step2 = self.test_run().add_step(f"{self.__class__.__name__} run(), step2")  # type: ignore
-        with step2.scope():
-            # uri = self.dut().uri_builder.format_uri(redfish_str="{BaseURI}/Chassis",
-            #                                     component_type="GPU")
-            result = self.dut().validate_redfish_service(file_name="RedfishServiceValidator", 
-                                        uri="/redfish/v1",
-                                        depth="Tree")
+        if result:
+            step2 = self.test_run().add_step(f"{self.__class__.__name__} run(), step2")  # type: ignore
+            with step2.scope():
+                file_name="RedfishServiceValidator"
+                base_uri = self.dut().uri_builder.format_uri(redfish_str="{GPUMC}",
+                                                                    component_type="GPU")
+                log_path = os.path.join(self.dut().logger_path, file_name)
+                schema_directory = f".{os.sep}SchemaFiles"
+                connection_url = self.dut().connection_url + base_uri
+                result = git.validate_redfish_service(file_name=file_name, connection_url=connection_url,
+                                                       user_name=self.dut().user_name, user_pass=self.dut().user_pass,
+                                                       log_path=self.dut().logger_path, schema_directory=schema_directory,
+                                                       depth="Tree",
+                                                       service_uri="/redfish/v1")
+                
         step3 = self.test_run().add_step(f"{self.__class__.__name__} run(), step3")  # type: ignore
         with step3.scope():
-            self.dut().clean_repo()
+            git.clean_repo()
         # ensure setting of self.result and self.score prior to calling super().run()
         self.result = TestResult.PASS if result else TestResult.FAIL
         if self.result == TestResult.PASS:

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_redfish_service_validator.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_redfish_service_validator.py
@@ -76,9 +76,9 @@ class CTAMTestServiceValidator(TestCase):
         with step2.scope():
             # uri = self.dut().uri_builder.format_uri(redfish_str="{BaseURI}/Chassis",
             #                                     component_type="GPU")
-            self.dut().validate_redfish_service(file_name="RedfishServiceValidator", 
-                                        uri="/redfish/v1/Chassis",
-                                        depth="Single")
+            result = self.dut().validate_redfish_service(file_name="RedfishServiceValidator", 
+                                        uri="/redfish/v1",
+                                        depth="Tree")
         step3 = self.test_run().add_step(f"{self.__class__.__name__} run(), step3")  # type: ignore
         with step3.scope():
             self.dut().clean_repo()

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_baseboard_gpu_processor_metrics.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_baseboard_gpu_processor_metrics.py
@@ -33,6 +33,7 @@ class CTAMTestTelemetryBaseboardGPUProcessorMetrics(TestCase):
     test_id: str = "T11"
     score_weight: int = 10
     tags: List[str] = []
+    compliance_level: str =""
 
     def __init__(self, group: BasicTelemetryTestGroup):
         """

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_chassis_assembly.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_chassis_assembly.py
@@ -33,6 +33,7 @@ class CTAMTestTelemetryChassisAssemblyMetrics(TestCase):
     test_id: str = "T12"
     score_weight: int = 10
     tags: List[str] = []
+    compliance_level: str =""
 
     def __init__(self, group: BasicTelemetryTestGroup):
         """

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_chassis_environment_metrics.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_chassis_environment_metrics.py
@@ -34,6 +34,7 @@ class CTAMTestTelemetryChassisEnvironmentMetrics(TestCase):
     test_id: str = "T48"
     score_weight: int = 10
     tags: List[str] = []
+    compliance_level: str =""
 
     def __init__(self, group: BasicTelemetryTestGroup):
         """

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_chassis_environment_metrics_reads.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_chassis_environment_metrics_reads.py
@@ -33,6 +33,7 @@ class CTAMTestTelemetryMRDListRead(TestCase):
     test_id: str = "T8"
     score_weight: int = 10
     tags: List[str] = []
+    compliance_level: str =""
 
     def __init__(self, group: BasicTelemetryTestGroup):
         """

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_chassis_fpga_metrics.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_chassis_fpga_metrics.py
@@ -33,6 +33,7 @@ class CTAMTestTelemetryChassisFpgaMetrics(TestCase):
     test_id: str = "T41"
     score_weight: int = 10
     tags: List[str] = []
+    compliance_level: str =""
 
     def __init__(self, group: BasicTelemetryTestGroup):
         """
@@ -63,6 +64,7 @@ class CTAMTestTelemetryChassisFpgaMetrics(TestCase):
         with step1.scope():
             if self.group.telemetry_ifc.ctam_get_chassis_fpga_metrics():
                 step1.add_log(LogSeverity.INFO, f"{self.test_id} : Passed")
+    
             else:
                 step1.add_log(LogSeverity.FATAL, f"{self.test_id} : Failed")
                 result = False

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_chassis_fpga_sensors_metrics.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_chassis_fpga_sensors_metrics.py
@@ -33,6 +33,7 @@ class CTAMTestTelemetryChassisFpgaSensorsMetrics(TestCase):
     test_id: str = "T42"
     score_weight: int = 10
     tags: List[str] = []
+    compliance_level: str =""
 
     def __init__(self, group: BasicTelemetryTestGroup):
         """

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_chassis_fpga_thermal_metrics.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_chassis_fpga_thermal_metrics.py
@@ -33,6 +33,7 @@ class CTAMTestTelemetryChassisFpgaThermalMetrics(TestCase):
     test_id: str = "T47"
     score_weight: int = 10
     tags: List[str] = []
+    compliance_level: str =""
 
     def __init__(self, group: BasicTelemetryTestGroup):
         """

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_chassis_ids_read.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_chassis_ids_read.py
@@ -33,6 +33,7 @@ class CTAMTestTelemetryChassisIDsRead(TestCase):
     test_id: str = "T17"
     score_weight: int = 10
     tags: List[str] = []
+    compliance_level: str =""
 
     def __init__(self, group: BasicTelemetryTestGroup):
         """

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_chassis_powersubsystem.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_chassis_powersubsystem.py
@@ -33,6 +33,7 @@ class CTAMTestTelemetryChassisPowerSubsystemMetrics(TestCase):
     test_id: str = "T13"
     score_weight: int = 10
     tags: List[str] = []
+    compliance_level: str =""
 
     def __init__(self, group: BasicTelemetryTestGroup):
         """

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_chassis_retimers_ThermalSubsystem_metrics.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_chassis_retimers_ThermalSubsystem_metrics.py
@@ -33,6 +33,7 @@ class CTAMTestTelemetryChassisRetimersThermalSubsystemMetrics(TestCase):
     test_id: str = "T45"
     score_weight: int = 10
     tags: List[str] = []
+    compliance_level: str =""
 
     def __init__(self, group: BasicTelemetryTestGroup):
         """

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_chassis_retimers_sensors_metrics.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_chassis_retimers_sensors_metrics.py
@@ -33,6 +33,7 @@ class CTAMTestTelemetryChassisRetimersSensorsMetrics(TestCase):
     test_id: str = "T44"
     score_weight: int = 10
     tags: List[str] = []
+    compliance_level: str =""
 
     def __init__(self, group: BasicTelemetryTestGroup):
         """

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_chassis_retimers_thermal_metrics.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_chassis_retimers_thermal_metrics.py
@@ -33,6 +33,7 @@ class CTAMTestTelemetryChassisRetimersThermalMetrics(TestCase):
     test_id: str = "T49"
     score_weight: int = 10
     tags: List[str] = []
+    compliance_level: str =""
 
     def __init__(self, group: BasicTelemetryTestGroup):
         """

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_chassis_sensor_ids_metrics.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_chassis_sensor_ids_metrics.py
@@ -33,6 +33,7 @@ class CTAMTestTelemetryChassisSensorIDsMetrics(TestCase):
     test_id: str = "T15"
     score_weight: int = 10
     tags: List[str] = []
+    compliance_level: str =""
 
     def __init__(self, group: BasicTelemetryTestGroup):
         """

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_chassis_sensors.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_chassis_sensors.py
@@ -33,6 +33,7 @@ class CTAMTestTelemetryChassisSensorsMetrics(TestCase):
     test_id: str = "T14"
     score_weight: int = 10
     tags: List[str] = []
+    compliance_level: str =""
 
     def __init__(self, group: BasicTelemetryTestGroup):
         """

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_chassis_system_fpga_metrics.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_chassis_system_fpga_metrics.py
@@ -33,6 +33,7 @@ class CTAMTestTelemetryChassisSystemFpgaMetrics(TestCase):
     test_id: str = "T40"
     score_weight: int = 10
     tags: List[str] = []
+    compliance_level: str =""
 
     def __init__(self, group: BasicTelemetryTestGroup):
         """

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_chassis_thermal_metrics.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_chassis_thermal_metrics.py
@@ -33,6 +33,7 @@ class CTAMTestTelemetryChassisThermalMetrics(TestCase):
     test_id: str = "T9"
     score_weight: int = 10
     tags: List[str] = []
+    compliance_level: str =""
 
     def __init__(self, group: BasicTelemetryTestGroup):
         """

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_chassis_thermal_subsystem.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_chassis_thermal_subsystem.py
@@ -33,6 +33,7 @@ class CTAMTestTelemetryChassisThermalSubsystem(TestCase):
     test_id: str = "T16"
     score_weight: int = 10
     tags: List[str] = []
+    compliance_level: str =""
 
     def __init__(self, group: BasicTelemetryTestGroup):
         """

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_gpu_thermal_metrics.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_gpu_thermal_metrics.py
@@ -33,6 +33,7 @@ class CTAMTestTelemetryGPUThermalMetrics(TestCase):
     test_id: str = "T10"
     score_weight: int = 10
     tags: List[str] = []
+    compliance_level: str =""
 
     def __init__(self, group: BasicTelemetryTestGroup):
         """

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_manager_set_sel_time.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_manager_set_sel_time.py
@@ -33,6 +33,7 @@ class CTAMTestTelemetryManagersEthernetInterfacesSetSelTime(TestCase):
     test_id: str = "T39"
     score_weight: int = 10
     tags: List[str] = []
+    compliance_level: str =""
 
     def __init__(self, group: BasicTelemetryTestGroup):
         """

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_managers_ethernet_interfaces.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_managers_ethernet_interfaces.py
@@ -33,6 +33,7 @@ class CTAMTestTelemetryManagersEthernetInterfaces(TestCase):
     test_id: str = "T36"
     score_weight: int = 10
     tags: List[str] = []
+    compliance_level: str =""
 
     def __init__(self, group: BasicTelemetryTestGroup):
         """

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_managers_gateway_change.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_managers_gateway_change.py
@@ -33,6 +33,7 @@ class CTAMTestTelemetryManagersEthernetInterfacesGatewayChange(TestCase):
     test_id: str = "T38"
     score_weight: int = 10
     tags: List[str] = []
+    compliance_level: str =""
 
     def __init__(self, group: BasicTelemetryTestGroup):
         """

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_managers_gateway_property.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_managers_gateway_property.py
@@ -33,6 +33,7 @@ class CTAMTestTelemetryManagersEthernetInterfacesGatewayProperty(TestCase):
     test_id: str = "T37"
     score_weight: int = 10
     tags: List[str] = []
+    compliance_level: str =""
 
     def __init__(self, group: BasicTelemetryTestGroup):
         """

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_managers_read.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_managers_read.py
@@ -33,6 +33,7 @@ class CTAMTestTelemetryManagersRead(TestCase):
     test_id: str = "T35"
     score_weight: int = 10
     tags: List[str] = []
+    compliance_level: str =""
 
     def __init__(self, group: BasicTelemetryTestGroup):
         """

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_mr_list_read.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_mr_list_read.py
@@ -33,6 +33,7 @@ class CTAMTestTelemetryMRListRead(TestCase):
     test_id: str = "T2"
     score_weight: int = 10
     tags: List[str] = []
+    compliance_level: str =""
 
     def __init__(self, group: BasicTelemetryTestGroup):
         """

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_mr_read.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_mr_read.py
@@ -33,6 +33,7 @@ class CTAMTestTelemetryMRRead(TestCase):
     test_id: str = "T4"
     score_weight: int = 10
     tags: List[str] = []
+    compliance_level: str =""
 
     def __init__(self, group: BasicTelemetryTestGroup):
         """

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_system_gpu_dram_environment_metrics.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_system_gpu_dram_environment_metrics.py
@@ -33,6 +33,7 @@ class CTAMTestTelemetrySystemsGPUDRAMEnvironmentMetrics(TestCase):
     test_id: str = "T29"
     score_weight: int = 10
     tags: List[str] = []
+    compliance_level: str =""
 
     def __init__(self, group: BasicTelemetryTestGroup):
         """

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_system_gpu_dram_memory_metrics.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_system_gpu_dram_memory_metrics.py
@@ -33,6 +33,7 @@ class CTAMTestTelemetrySystemsGPUMemoryDRAMMetrics(TestCase):
     test_id: str = "T28"
     score_weight: int = 10
     tags: List[str] = []
+    compliance_level: str =""
 
     def __init__(self, group: BasicTelemetryTestGroup):
         """

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_system_gpu_memory_dram_ids.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_system_gpu_memory_dram_ids.py
@@ -33,6 +33,7 @@ class CTAMTestTelemetrySystemsGPUMemoryDRAMIDs(TestCase):
     test_id: str = "T27"
     score_weight: int = 10
     tags: List[str] = []
+    compliance_level: str =""
 
     def __init__(self, group: BasicTelemetryTestGroup):
         """

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_systems_baseboard_id.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_systems_baseboard_id.py
@@ -33,6 +33,7 @@ class CTAMTestTelemetrySystemsBaseboardIds(TestCase):
     test_id: str = "T18"
     score_weight: int = 10
     tags: List[str] = []
+    compliance_level: str =""
 
     def __init__(self, group: BasicTelemetryTestGroup):
         """

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_systems_environment_metrics.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_systems_environment_metrics.py
@@ -34,6 +34,7 @@ class CTAMTestTelemetrySystemsEnvironmentMetrics(TestCase):
     test_id: str = "T23"
     score_weight: int = 10
     tags: List[str] = []
+    compliance_level: str =""
 
     def __init__(self, group: BasicTelemetryTestGroup):
         """

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_systems_gpu_metrics.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_systems_gpu_metrics.py
@@ -34,6 +34,7 @@ class CTAMTestTelemetrySystemsGPUMetrics(TestCase):
     test_id: str = "T22"
     score_weight: int = 10
     tags: List[str] = []
+    compliance_level: str =""
 
     def __init__(self, group: BasicTelemetryTestGroup):
         """

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_systems_gpu_ports.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_systems_gpu_ports.py
@@ -34,6 +34,7 @@ class CTAMTestTelemetrySystemsGPUPorts(TestCase):
     test_id: str = "T24"
     score_weight: int = 10
     tags: List[str] = []
+    compliance_level: str =""
 
     def __init__(self, group: BasicTelemetryTestGroup):
         """

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_systems_gpu_ports_ids.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_systems_gpu_ports_ids.py
@@ -33,6 +33,7 @@ class CTAMTestTelemetrySystemsGPUPortsIDs(TestCase):
     test_id: str = "T25"
     score_weight: int = 10
     tags: List[str] = []
+    compliance_level: str =""
 
     def __init__(self, group: BasicTelemetryTestGroup):
         """

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_systems_gpu_ports_ids_metrics.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_systems_gpu_ports_ids_metrics.py
@@ -33,6 +33,7 @@ class CTAMTestTelemetrySystemsGPUPortsIDsMetrics(TestCase):
     test_id: str = "T26"
     score_weight: int = 10
     tags: List[str] = []
+    compliance_level: str =""
 
     def __init__(self, group: BasicTelemetryTestGroup):
         """

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_systems_logservices.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_systems_logservices.py
@@ -33,6 +33,7 @@ class CTAMTestTelemetrySystemsLogServices(TestCase):
     test_id: str = "T21"
     score_weight: int = 10
     tags: List[str] = []
+    compliance_level: str =""
 
     def __init__(self, group: BasicTelemetryTestGroup):
         """

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_systems_memory.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_systems_memory.py
@@ -33,6 +33,7 @@ class CTAMTestTelemetrySystemsMemory(TestCase):
     test_id: str = "T20"
     score_weight: int = 10
     tags: List[str] = []
+    compliance_level: str =""
 
     def __init__(self, group: BasicTelemetryTestGroup):
         """

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_systems_processors.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_systems_processors.py
@@ -33,6 +33,7 @@ class CTAMTestTelemetrySystemsProcessors(TestCase):
     test_id: str = "T19"
     score_weight: int = 10
     tags: List[str] = []
+    compliance_level: str =""
 
     def __init__(self, group: BasicTelemetryTestGroup):
         """

--- a/ctam/utils/ctam_utils.py
+++ b/ctam/utils/ctam_utils.py
@@ -1,0 +1,122 @@
+import os
+import shlex
+import subprocess
+import shutil
+import stat
+from os import path
+import tempfile
+
+from alive_progress import alive_bar
+
+class GitUtils():
+
+    def __init__(self) -> None:
+        self.repo_path = ""
+        self.temp_dir = tempfile.gettempdir()
+        pass
+
+    def clone_repo(self, repo_url, repo_path, branch_name="", install_requirements=True):
+        try:
+            self.repo_path = os.path.join(self.temp_dir, repo_path)
+
+            if not os.path.exists(self.repo_path):
+                os.makedirs(self.repo_path)
+            branch = ""
+            if branch_name:
+                branch = f"-b {branch_name}"
+            cmd = f"git clone {branch} {repo_url} {self.repo_path}"
+            print(cmd)
+            result = subprocess.run(shlex.split(cmd, posix=False), capture_output=True)
+            print(result)
+            if result.returncode != 0 and result.stderr:
+                error = result.stderr.decode("utf-8").strip()
+                msg = f"Exception occurred while cloning a repo. Please see below exception...\n{error}"
+                raise Exception(msg)
+            if install_requirements:
+                for filename in os.listdir(self.repo_path):
+                    if "requirement" in filename:
+                        cmd = "python -m pip install -r {} ".format(os.path.join(self.repo_path, filename))
+                        res  =subprocess.run(shlex.split(cmd, posix=False))
+                        # res.check_returncode()
+                        if res.returncode != 0 and res.stderr:
+                            error = result.stderr.decode("utf-8").strip()
+                            msg = f"Exception occurred while installing python pip packages. Please see below exception...\n{error}"
+                            raise Exception(msg)
+            return True
+        except Exception as e:
+            print(e)
+            return False
+
+    def clean_repo(self, repo_path=""):
+        try:
+            if not repo_path:
+                repo_path = self.repo_path
+            
+            for root, dirs, files in os.walk(self.repo_path):  
+                for dir in dirs:
+                    os.chmod(path.join(root, dir), stat.S_IRWXU)
+                for file in files:
+                    os.chmod(path.join(root, file), stat.S_IRWXU)
+            shutil.rmtree(repo_path)
+            return True
+        except Exception as e:
+            print(f"Exception occurred while cleaning up the git repo. Please remove manually...\n{str(e)}")
+            return False
+
+
+    def validate_redfish_service(self, file_name, connection_url, user_name, user_pass,
+                                  log_path, schema_directory, depth, service_uri, *args, **kwargs):
+            
+            log_path = os.path.join(log_path, file_name)
+            file_name = os.path.join(self.repo_path, file_name)
+            schema_directory = os.path.join(self.repo_path, "SchemaFiles")
+            try:
+                service_command = "python {file_name}.py --ip {ip} \
+                        -u {user} -p {pwd} --logdir {log_dir} \
+                        --schema_directory {schema_directory} \
+                            --payload {depth} {uri}".format(
+                                file_name=file_name,
+                                ip=connection_url,
+                                user=user_name,
+                                pwd=user_pass,
+                                log_dir=log_path,
+                                schema_directory=schema_directory,
+                                depth=depth,
+                                uri=service_uri
+                            )
+                with alive_bar(0,theme="classic", stats=False) as bar:
+                    result = subprocess.run(shlex.split(service_command, posix=False), capture_output=True)
+                    print(result.returncode, result.stderr)
+                    if result.returncode != 0 and result.stderr:
+                        error = result.stderr.decode("utf-8").strip()
+                        raise Exception(error)
+                    bar()
+                    result = result.stdout.decode("utf-8").strip()
+                    # print("Res: ",result)
+                    data = result.replace("\r", "").split("\n")[-1]
+                    # print("Data: ", data)
+                    s_idx = result.index("Elapsed time:")
+                    data = result[s_idx:]
+                    # print("Index: ", data)
+                    import re
+                    res = re.findall(r"pass:\s+(\d+)", data)
+                    print("REGEX: ",res)
+                    if res and res[0].isdigit() and int(res[0]) > 0:
+                        # res = int(res[0])
+                        # if res > 0:
+                        return True
+                    # if "fail" in data.lower():
+                    #     msg = "Redfish ServiceVerification has failed. Please check log file for more details."
+                    #     print(msg)
+                    #     return False
+                    return False
+            except Exception as e:
+                print(f"Exception Occurred: {e}")
+                return False
+    
+# def show_loading_bar():
+#     with alive_bar(0,theme="classic", stats=False) as bar:
+#         result = subprocess.run(shlex.split(run_command), capture_output=True)
+#         bar()
+#         if result.stderr:
+#             raise Exception(result.stderr)

--- a/json_spec/input/dut_info.json
+++ b/json_spec/input/dut_info.json
@@ -4,11 +4,6 @@
   "title": "dut_info",
   "description": "TODO: link to md doc",
   "properties": {
-    "ConnectionTo": {
-      "description": "Acceptable values are UtilityManager, Node*MC, Gpu*MC",
-      "type": "string",
-      "value": ""
-    },
     "ConnectionIPAddress": {
       "description": "IP Address of Service Entry point to be used",
       "type": "string",
@@ -23,11 +18,6 @@
       "description": "Indicates if REST API authentication is required by the Redfish service",
       "type": "bool",
       "value": false
-    },
-    "DefaultPrefix": {
-      "description": "Default preix for connecting to redfish",
-      "type": "string",
-      "value": ""
     },
     "BMCUserName": {
       "description": "Username for service entry login",

--- a/json_spec/input/dut_info.json
+++ b/json_spec/input/dut_info.json
@@ -88,6 +88,11 @@
       "description": "Maximum time in seconds taken by activation phase of full device FW update",
       "type": "int",
       "value": 600
+    },
+    "IdleWaitTimeAfterFirmwareUpdate":{
+      "description": "Wait time (in seconds) for runtime execution delay",
+      "type": "int",
+      "value": 300
     }
   },
   "required": [
@@ -99,6 +104,7 @@
     "PowerOffWaitTime",
     "PowerOnWaitTime",
     "FwStagingTimeMax",
-    "FwActivationTimeMax"
+    "FwActivationTimeMax",
+    "IdleWaitTimeAfterFirmwareUpdate"
   ]
 }

--- a/json_spec/input/test_runner.json
+++ b/json_spec/input/test_runner.json
@@ -14,6 +14,9 @@
     "weighted_score": {
         "L0": 100, "L1": 50, "L2": 20, "L3": 0, "Others": 10
     },
+    "normalized_score": {
+        "L0": 50, "L1": 35, "L2": 15, "L3": 0
+    },
     "active_test_suite": [],
     "dev_test_suite": [],
     "full_compliance_test_suite": [],

--- a/json_spec/input/test_runner.json
+++ b/json_spec/input/test_runner.json
@@ -11,7 +11,10 @@
     "exclude_tags": [],
     "test_sequence" : [],
     "group_sequence" : [],
-    "active_test_suite": "",
+    "weighted_score": {
+        "L0": 100, "L1": 50, "L2": 20, "L3": 0, "Others": 10
+    },
+    "active_test_suite": [],
     "dev_test_suite": [],
     "full_compliance_test_suite": [],
     "regression_test_suite_0": ["F0","F1", "F63", "F64", "F8", "F88", "T0"],

--- a/json_spec/input/test_runner.json
+++ b/json_spec/input/test_runner.json
@@ -14,7 +14,8 @@
     "active_test_suite": "",
     "dev_test_suite": [],
     "full_compliance_test_suite": [],
-    "regression_test_suite_0": [],
-    "regression_test_suite_1": [],
+    "regression_test_suite_0": ["F0","F1", "F63", "F64", "F8", "F88", "T0"],
+    "regression_test_suite_1": ["F0", "F1", "F23", "F26", "F28", "F27", "F22", "F25", "F18", "F32"],
+    "regression_test_suite_2": ["F0", "F1", "F16", "F19", "F55", "F62", "F89"],
     "test_uri_response_excel":"Excel file name for checking the response"
 }

--- a/json_spec/input/test_runner.json
+++ b/json_spec/input/test_runner.json
@@ -11,11 +11,10 @@
     "exclude_tags": [],
     "test_sequence" : [],
     "group_sequence" : [],
-    "command_output_log_path": "",
     "active_test_suite": "",
-    "dev_test_suite": [
-    ],
-    "full_compliance_test_suite": [
-    ],
+    "dev_test_suite": [],
+    "full_compliance_test_suite": [],
+    "regression_test_suite_0": [],
+    "regression_test_suite_1": [],
     "test_uri_response_excel":"Excel file name for checking the response"
 }


### PR DESCRIPTION
Regression Suite 0
![image](https://github.com/opencomputeproject/ocp-diag-ctam/assets/139941972/96e4ebe1-2e8d-4175-a62b-7d987f1766b0)

Framework Changes
1. Execution mechanism using tags using include tags, exclude tags, test case tags and test group tags. 
2. Test case list (-l) now displayed in tabular form with tag information per test case and group. 
3. Multiple regression suites to choose from. (refer test_runner.json file from json_spec) 
4. dut_info json file includes IdleWaitTimeAfterFirmwareUpdate (default is 5mins to overcome issues related to rate limiting)
5. Now all test cases get invoked if option is provided (with only workspace). 

Test Case changes 
1. All test cases have been tagged with L0, L1, L2 , L3. L3 test cases are not a part of compliance. 
2. Removed unnecessary power cycles after many negative test cases. Only few test cases have this today. 
3. Service validator bugs fixed. Plus we have a progress bar too. 
4. Stagingtime and Activationtime are recorded for test run optimization (for F63 and F64). 
5. AC cycle test case (L3 test case) will not check for GPU goodness on return - reduces dependency during tool enabling. 
7. Reduced initial collateral dependency for ease of onboarding. 
8. Clear Log Dump test case is tolerant to redfish return code of 204 or 200 (despite no json body return in either case). 
9. Corrected file names of F24 (full device) and F62 (single device) negative test cases with AC reset interruption. 