### PR TITLE
Remove duplicates in pip-requirements

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -8,14 +8,11 @@
 #  pip install -r pip-requirements.txt
 ##
 
-alive-progress
 ocptv
 prettytable
 redfish
 regex
 mypy
-black
-bumpver
 isort
 pip-tools
 pytest


### PR DESCRIPTION
Summary: Cleanup pip-requirements by removing packages that are called out twice, removing the unversioned instances
Signed-off-by: Venkat Ramesh venkatraghavan@fb.com