### PR TITLE
Fix for F8 Test Case

### DIFF
--- a/ctam/ctam.py
+++ b/ctam/ctam.py
@@ -158,7 +158,7 @@ def main():
     dut_info_json = os.path.join(args.workspace, "dut_info.json")
     package_info_json = os.path.join(args.workspace, "package_info.json")
     redfish_uri_config = os.path.join(args.workspace, "redfish_uri_config.json")
-    redfish_response_config = os.path.join(args.workspace, "redfish_response.json")
+    redfish_response_messages = os.path.join(args.workspace, "redfish_response_messages.json")
     net_rc = os.path.join(args.workspace, ".netrc")
 
     # NOTE: We have added internal test directory as mandatory if 'internal_testing' is true in test runner json.
@@ -192,7 +192,7 @@ def main():
             dut_info_json_file=dut_info_json,
             package_info_json_file=package_info_json,
             redfish_uri_config_file=redfish_uri_config,
-            redfish_response_config_file=redfish_response_config,
+            redfish_response_messages=redfish_response_messages,
             net_rc=net_rc,
         )
         status_code, exit_string = runner.get_system_details()
@@ -206,7 +206,7 @@ def main():
             dut_info_json_file=dut_info_json,
             package_info_json_file=package_info_json,
             redfish_uri_config_file=redfish_uri_config,
-            redfish_response_config_file=redfish_response_config,
+            redfish_response_messages=redfish_response_messages,
             net_rc=net_rc,
             single_test_override=args.testcase,
         )
@@ -218,7 +218,7 @@ def main():
             dut_info_json_file=dut_info_json,
             package_info_json_file=package_info_json,
             redfish_uri_config_file=redfish_uri_config,
-            redfish_response_config_file=redfish_response_config,
+            redfish_response_messages=redfish_response_messages,
             net_rc=net_rc,
             sequence_test_override=args.testcase_sequence,
         )
@@ -230,7 +230,7 @@ def main():
             dut_info_json_file=dut_info_json,
             package_info_json_file=package_info_json,
             redfish_uri_config_file=redfish_uri_config,
-            redfish_response_config_file=redfish_response_config,
+            redfish_response_messages=redfish_response_messages,
             net_rc=net_rc,
             single_group_override=args.group,
         )
@@ -242,7 +242,7 @@ def main():
             dut_info_json_file=dut_info_json,
             package_info_json_file=package_info_json,
             redfish_uri_config_file=redfish_uri_config,
-            redfish_response_config_file=redfish_response_config,
+            redfish_response_messages=redfish_response_messages,
             net_rc=net_rc,
             sequence_group_override=args.group_sequence,
         )
@@ -256,7 +256,7 @@ def main():
             package_info_json_file=package_info_json,
             net_rc=net_rc,
             redfish_uri_config_file=redfish_uri_config,
-            redfish_response_config_file=redfish_response_config,
+            redfish_response_messages=redfish_response_messages,
             run_all_tests=all_tests
         )
 

--- a/ctam/ctam.py
+++ b/ctam/ctam.py
@@ -57,6 +57,8 @@ def parse_args():
     )
 
     parser.add_argument("-d", "--Discovery", help="Perform System Discovery", action="store_true")
+    
+    # parser.add_argument("-x", "--Discovery", help="Perform System Discovery", action="store_true")
 
     parser.add_argument(
         "-l",
@@ -156,6 +158,7 @@ def main():
     dut_info_json = os.path.join(args.workspace, "dut_info.json")
     package_info_json = os.path.join(args.workspace, "package_info.json")
     redfish_uri_config = os.path.join(args.workspace, "redfish_uri_config.json")
+    redfish_response_config = os.path.join(args.workspace, "redfish_response.json")
     net_rc = os.path.join(args.workspace, ".netrc")
 
     # NOTE: We have added internal test directory as mandatory if 'internal_testing' is true in test runner json.
@@ -189,6 +192,7 @@ def main():
             dut_info_json_file=dut_info_json,
             package_info_json_file=package_info_json,
             redfish_uri_config_file=redfish_uri_config,
+            redfish_response_config_file=redfish_response_config,
             net_rc=net_rc,
         )
         status_code, exit_string = runner.get_system_details()
@@ -202,6 +206,7 @@ def main():
             dut_info_json_file=dut_info_json,
             package_info_json_file=package_info_json,
             redfish_uri_config_file=redfish_uri_config,
+            redfish_response_config_file=redfish_response_config,
             net_rc=net_rc,
             single_test_override=args.testcase,
         )
@@ -213,6 +218,7 @@ def main():
             dut_info_json_file=dut_info_json,
             package_info_json_file=package_info_json,
             redfish_uri_config_file=redfish_uri_config,
+            redfish_response_config_file=redfish_response_config,
             net_rc=net_rc,
             sequence_test_override=args.testcase_sequence,
         )
@@ -224,6 +230,7 @@ def main():
             dut_info_json_file=dut_info_json,
             package_info_json_file=package_info_json,
             redfish_uri_config_file=redfish_uri_config,
+            redfish_response_config_file=redfish_response_config,
             net_rc=net_rc,
             single_group_override=args.group,
         )
@@ -235,6 +242,7 @@ def main():
             dut_info_json_file=dut_info_json,
             package_info_json_file=package_info_json,
             redfish_uri_config_file=redfish_uri_config,
+            redfish_response_config_file=redfish_response_config,
             net_rc=net_rc,
             sequence_group_override=args.group_sequence,
         )
@@ -248,6 +256,7 @@ def main():
             package_info_json_file=package_info_json,
             net_rc=net_rc,
             redfish_uri_config_file=redfish_uri_config,
+            redfish_response_config_file=redfish_response_config,
             run_all_tests=all_tests
         )
 

--- a/ctam/interfaces/comptool_dut.py
+++ b/ctam/interfaces/comptool_dut.py
@@ -89,7 +89,8 @@ class CompToolDut(Dut):
         self.__user_name, _, self.__user_pass = self.net_rc.authenticators(
             self.connection_ip_address
         )
-        self.multipart_form_data = self.default_prefix = self.uri_builder.format_uri(redfish_str="{MultiPartFormData}", component_type="GPU")
+        # self.default_prefix = self.uri_builder.format_uri(redfish_str="{MultiPartFormData}", component_type="GPU")
+        self.multipart_form_data = self.uri_builder.format_uri(redfish_str="{MultiPartFormData}", component_type="GPU")
         
         self.binded_port = None
         self.SSHTunnelRemoteIPAddress = None

--- a/ctam/interfaces/comptool_dut.py
+++ b/ctam/interfaces/comptool_dut.py
@@ -49,7 +49,7 @@ class CompToolDut(Dut):
         logger,
         test_info_logger,
         test_uri_response_check,
-        redfish_response_config,
+        redfish_response_messages,
         logger_path,
         name: ty.Optional[str] = None,
         metadata: ty.Optional[Metadata] = None,
@@ -78,7 +78,7 @@ class CompToolDut(Dut):
         self.logger_path = logger_path
         self.test_info_logger = test_info_logger
         self.test_uri_response_check = test_uri_response_check
-        self.redfish_response_config = redfish_response_config
+        self.redfish_response_messages = redfish_response_messages
         self.cwd = self.get_cwd()
         super().__init__(id, name, metadata)
         self.connection_ip_address = config["properties"]["ConnectionIPAddress"][

--- a/ctam/interfaces/comptool_dut.py
+++ b/ctam/interfaces/comptool_dut.py
@@ -49,6 +49,7 @@ class CompToolDut(Dut):
         logger,
         test_info_logger,
         test_uri_response_check,
+        redfish_response_config,
         logger_path,
         name: ty.Optional[str] = None,
         metadata: ty.Optional[Metadata] = None,
@@ -77,6 +78,7 @@ class CompToolDut(Dut):
         self.logger_path = logger_path
         self.test_info_logger = test_info_logger
         self.test_uri_response_check = test_uri_response_check
+        self.redfish_response_config = redfish_response_config
         self.cwd = self.get_cwd()
         super().__init__(id, name, metadata)
         self.connection_ip_address = config["properties"]["ConnectionIPAddress"][

--- a/ctam/interfaces/functional_ifc.py
+++ b/ctam/interfaces/functional_ifc.py
@@ -308,6 +308,7 @@ class FunctionalIfc:
                 self.dut().package_config.get("GPU_FW_IMAGE_CORRUPT_COMPONENT", {}).get("Path", ""),
                 self.dut().package_config.get("GPU_FW_IMAGE_CORRUPT_COMPONENT", {}).get("JSON", ""),
             )
+            
         return pldm_json_file
 
     def ctam_getfi(self, expanded=0):
@@ -654,7 +655,7 @@ class FunctionalIfc:
             print(str(e))
             return None
     
-    def ctam_monitor_task(self, TaskID):
+    def ctam_monitor_task(self, TaskID=""):
         """
         :Description:       CTAM Monitor a Task
         :param TaskID       Task ID of TaskService/Tasks (for accelerator management) to monitor
@@ -662,8 +663,15 @@ class FunctionalIfc:
         :rtype:             Tuple
         """
         Task_Completed = False
+        JSONData = {}
+        if not TaskID:
+            # need to implement the flow for no task uri
+            self.test_run().add_log(LogSeverity.DEBUG,
+                    "No Task ID provided."
+                )
+            return Task_Completed, JSONData
         TaskURI = self.dut().uri_builder.format_uri(
-            redfish_str="{BaseURI}/TaskService/Tasks/" + "{}".format(TaskID), component_type="GPU"
+            redfish_str="{BaseURI}{TaskServiceURI}" + "{}".format(TaskID), component_type="GPU"
         )
         if self.dut().is_debug_mode():
             self.test_run().add_log(LogSeverity.DEBUG, f"Task URI: {TaskURI}")
@@ -678,13 +686,25 @@ class FunctionalIfc:
                     "Task Percentage_Completion = {}".format(JSONData["PercentComplete"])
                 )
             time.sleep(30)
-        if JSONData["TaskState"] == "Completed":
+        if JSONData["TaskState"] == "Completed" and JSONData["TaskStatus"] == "OK":
             Task_Completed = True
         else:
             Task_Completed = False
         
         return Task_Completed, JSONData
 
+
+    def check_all_staging_tasks(self):
+        task_service_uri = self.dut().uri_builder.format_uri(
+            redfish_str="{BaseURI}{TaskServiceURI}", component_type="GPU"
+        )
+        response = self.dut().run_redfish_command(uri=task_service_uri)
+        json_data = response.dict
+        task_list = [i["@odata.id"] for i in json_data["Members"]]
+        for task in task_list:
+            self.ctam_monitor_task(TaskID=task)
+    
+    
     
     def ctam_redfish_uri_deep_hunt(self, URI, uri_hunt="", uri_listing=[], uri_analyzed=[],action=0):
         """

--- a/ctam/interfaces/fw_update_ifc.py
+++ b/ctam/interfaces/fw_update_ifc.py
@@ -236,7 +236,7 @@ class FWUpdateIfc(FunctionalIfc, metaclass=Meta):
                 if not message:
                     message = JSONData.get("error", {}).get("code", "")
                 print("message is 01: ", message)
-                resp_msg = self.dut().redfish_response_config.get("UpdateProgress", "UnexpectedMessage")
+                resp_msg = self.dut().redfish_response_messages.get("UpdateProgress_Message", "UnexpectedMessage")
                 if resp_msg:
                     if message.split(".")[-1].lower() != resp_msg.lower():
                         StageFWOOB_Status = False

--- a/ctam/interfaces/fw_update_ifc.py
+++ b/ctam/interfaces/fw_update_ifc.py
@@ -231,13 +231,17 @@ class FWUpdateIfc(FunctionalIfc, metaclass=Meta):
         else:
             error_check = JSONData.get("error", None)
             if error_check and image_type != "large":
-                message = JSONData.get("error", {}).get("@Message.ExtendedInfo", {}).get("MessageId", "")
+                message = JSONData.get("error", {}).get("@Message.ExtendedInfo", {})[0].get("MessageId", "")
+                print("message is : ", message)
                 if not message:
                     message = JSONData.get("error", {}).get("code", "")
-                
-                if message.split(".")[-1].lower() != "UpdateInProgress".lower():
-                    StageFWOOB_Status = False
-                    stage_msg = "UnexpectedMessage"
+                print("message is 01: ", message)
+                resp_msg = self.dut().redfish_response_config.get("UpdateProgress", "UnexpectedMessage")
+                if resp_msg:
+                    if message.split(".")[-1].lower() != resp_msg.lower():
+                        StageFWOOB_Status = False
+                        stage_msg = "UnexpectedMessage"
+                        
             if image_type == "large":
                 GPULargeFWMessage = "{GPULargeFWMessage}".format(**self.dut().redfish_uri_config.get("GPU"))
                 if GPULargeFWMessage in JSONData["error"] or GPULargeFWMessage in JSONData["error"].get("message", {}) : # FIXME: Temp fix to make it work in both MSFT and Nvidia systems

--- a/ctam/test_runner.py
+++ b/ctam/test_runner.py
@@ -52,6 +52,7 @@ class TestRunner:
         dut_info_json_file,
         package_info_json_file,
         redfish_uri_config_file,
+        redfish_response_config_file,
         net_rc,
         single_test_override=None,
         sequence_test_override=None,
@@ -103,6 +104,7 @@ class TestRunner:
         self.console_log = True
         self.progress_bar = False
         self.package_config = package_info_json_file
+        self.redfish_response_config = None
         runner_config = self._get_test_runner_config(test_runner_json_file)
 
         with open(dut_info_json_file) as dut_info_json:
@@ -115,6 +117,10 @@ class TestRunner:
             self.redfish_uri_config = json.load(redfish_uri)
 
         self.net_rc = netrc.netrc(net_rc)
+        
+        if redfish_response_config_file:
+            with open(redfish_response_config_file) as resp_file:
+                self.redfish_response_config = json.load(resp_file)
 
         # use override output directory if specified in test_runner.json, otherwise
         # use TestRuns directory below workspace directory
@@ -280,6 +286,7 @@ class TestRunner:
             logger=dut_logger,
             test_info_logger=test_info_logger,
             test_uri_response_check=self.test_uri_response_check,
+            redfish_response_config=self.redfish_response_config,
             logger_path=self.output_dir
         )
         self.comp_tool_dut.current_test_name = "Initialization"

--- a/ctam/test_runner.py
+++ b/ctam/test_runner.py
@@ -52,7 +52,7 @@ class TestRunner:
         dut_info_json_file,
         package_info_json_file,
         redfish_uri_config_file,
-        redfish_response_config_file,
+        redfish_response_messages,
         net_rc,
         single_test_override=None,
         sequence_test_override=None,
@@ -104,7 +104,7 @@ class TestRunner:
         self.console_log = True
         self.progress_bar = False
         self.package_config = package_info_json_file
-        self.redfish_response_config = None
+        self.redfish_response_messages = {}
         runner_config = self._get_test_runner_config(test_runner_json_file)
 
         with open(dut_info_json_file) as dut_info_json:
@@ -118,9 +118,9 @@ class TestRunner:
 
         self.net_rc = netrc.netrc(net_rc)
         
-        if redfish_response_config_file:
-            with open(redfish_response_config_file) as resp_file:
-                self.redfish_response_config = json.load(resp_file)
+        if redfish_response_messages:
+            with open(redfish_response_messages) as resp_file:
+                self.redfish_response_messages = json.load(resp_file)
 
         # use override output directory if specified in test_runner.json, otherwise
         # use TestRuns directory below workspace directory
@@ -286,7 +286,7 @@ class TestRunner:
             logger=dut_logger,
             test_info_logger=test_info_logger,
             test_uri_response_check=self.test_uri_response_check,
-            redfish_response_config=self.redfish_response_config,
+            redfish_response_messages=self.redfish_response_messages,
             logger_path=self.output_dir
         )
         self.comp_tool_dut.current_test_name = "Initialization"

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_activation_time.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_activation_time.py
@@ -78,7 +78,8 @@ class CTAMTestFullDeviceUpdateActivationTime(TestCase):
 
         step2 = self.test_run().add_step(f"{self.__class__.__name__} run(), step2")  # type: ignore
         with step2.scope():
-            if self.group.fw_update_ifc.ctam_stage_fw():
+            status, msg, task_id = self.group.fw_update_ifc.ctam_stage_fw()
+            if status:
                 step2.add_log(LogSeverity.INFO, f"{self.test_id} : FW Update Staged")
             else:
                 step2.add_log(

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_activation_with_failed_component.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_activation_with_failed_component.py
@@ -93,10 +93,10 @@ class CTAMTestFullDeviceUpdateActivationWithFailedComponent(TestCase):
 
             step2 = self.test_run().add_step(f"{self.__class__.__name__} run(), step2")  # type: ignore
             with step2.scope():
-                if self.group.fw_update_ifc.ctam_stage_fw(
-                    image_type="corrupt_component", 
+                status, msg, task_id = self.group.fw_update_ifc.ctam_stage_fw(image_type="corrupt_component", 
                     corrupted_component_id=self.corrupted_component_id
-                    ):
+                    )
+                if status:
                     step2.add_log(LogSeverity.INFO, f"{self.test_id} : FW Update Staged")
                 else:
                     step2.add_log(

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_in_loop.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_in_loop.py
@@ -80,8 +80,8 @@ class CTAMTestFullDeviceUpdateInLoop(TestCase):
 
         step2 = self.test_run().add_step(f"{self.__class__.__name__} run(), step2")  # type: ignore
         with step2.scope():
-            status, _, task_uri =self.group.fw_update_ifc.ctam_stage_fw(
-                wait_for_stage_completion=False, return_msg=True
+            status, _, task_id =self.group.fw_update_ifc.ctam_stage_fw(
+                wait_for_stage_completion=False
             )
             if status:
                 step2.add_log(LogSeverity.INFO, f"{self.test_id} : FW Update Staged")
@@ -97,7 +97,7 @@ class CTAMTestFullDeviceUpdateInLoop(TestCase):
             unexpected_error = False
             disturb_count = 1
             while keep_disturbing:
-                status, msg, _ = self.group.fw_update_ifc.ctam_stage_fw(image_type="backup", return_msg=True)
+                status, msg, _ = self.group.fw_update_ifc.ctam_stage_fw(image_type="backup")
                 if status:
                     keep_disturbing = False
                     step3.add_log(
@@ -124,12 +124,12 @@ class CTAMTestFullDeviceUpdateInLoop(TestCase):
                     LogSeverity.ERROR,
                     f"{self.test_id} : FW Update Disturb was successful in first shot - Not Expected",
                 )
-            if unexpected_error and task_uri:
+            if unexpected_error and task_id:
                 step3.add_log(
                     LogSeverity.ERROR,
                     f"{self.test_id} : FW Update Failed with Unexpected error - Waiting for pervious FW staging to be completed",
                 )
-                status = self.group.fw_update_ifc.wait_for_staging(TaskID=task_uri)
+                status, json_data = self.group.fw_update_ifc.ctam_monitor_task(TaskID=task_id)
                 
 
         if result or unexpected_error:

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_ping_pong.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_ping_pong.py
@@ -88,7 +88,8 @@ class CTAMTestFullDeviceUpdatePingPong(TestCase):
             if result:
                 step2 = self.test_run().add_step(f"{self.__class__.__name__} run(), step2")  # type: ignore
                 with step2.scope():
-                    if self.group.fw_update_ifc.ctam_stage_fw(image_type=image_t):
+                    status, status_msg, task_id = self.group.fw_update_ifc.ctam_stage_fw(image_type=image_t)
+                    if status:
                         step2.add_log(
                             LogSeverity.INFO, f"{self.test_id} : FW Update Staged"
                         )

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_rollback.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_rollback.py
@@ -80,7 +80,8 @@ class CTAMTestFullDeviceUpdateRollback(TestCase):
 
         step2 = self.test_run().add_step(f"{self.__class__.__name__} run(), step2")  # type: ignore
         with step2.scope():
-            if self.group.fw_update_ifc.ctam_stage_fw(image_type="backup"):
+            status, status_msg, task_id = self.group.fw_update_ifc.ctam_stage_fw(image_type="backup")
+            if status:
                 step2.add_log(LogSeverity.INFO, f"{self.test_id} : FW Update Staged")
             else:
                 step2.add_log(

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_staging_time.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_staging_time.py
@@ -78,7 +78,8 @@ class CTAMTestFullDeviceUpdateStagingTime(TestCase):
 
         step2 = self.test_run().add_step(f"{self.__class__.__name__} run(), step2")  # type: ignore
         with step2.scope():
-            if self.group.fw_update_ifc.ctam_stage_fw(check_time=True):
+            status, status_msg, task_id = self.group.fw_update_ifc.ctam_stage_fw(check_time=True)
+            if status:
                 step2.add_log(LogSeverity.INFO, f"{self.test_id} : FW Update Staged")
             else:
                 step2.add_log(

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_staging_with_failed_component.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_staging_with_failed_component.py
@@ -93,10 +93,10 @@ class CTAMTestFullDeviceUpdateStagingWithFailedComponent(TestCase):
 
             step2 = self.test_run().add_step(f"{self.__class__.__name__} run(), step2")  # type: ignore
             with step2.scope():
-                if self.group.fw_update_ifc.ctam_stage_fw(
-                    image_type="corrupt_component", 
+                status, status_msg, task_id = self.group.fw_update_ifc.ctam_stage_fw(image_type="corrupt_component", 
                     corrupted_component_id=self.corrupted_component_id
-                    ):
+                    )
+                if status:
                     step2.add_log(LogSeverity.INFO, f"{self.test_id} : FW Update Staged")
                 else:
                     step2.add_log(

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_with_older_version.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_with_older_version.py
@@ -87,7 +87,8 @@ class CTAMTestFullDeviceUpdateWithOlderVersion(TestCase):
         if result:
             step2 = self.test_run().add_step(f"{self.__class__.__name__} run(), step2")  # type: ignore
             with step2.scope():
-                if self.group.fw_update_ifc.ctam_stage_fw(image_type=image_t):
+                status, status_msg, task_id = self.group.fw_update_ifc.ctam_stage_fw(image_type=image_t)
+                if status:
                     step2.add_log(
                         LogSeverity.INFO, f"{self.test_id} : FW Update Staged"
                     )

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_corrupt_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_corrupt_image_update.py
@@ -70,7 +70,8 @@ class CTAMTestNegativeCorruptImageUpdate(TestCase):
         result = True
         step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
         with step1.scope():
-            if self.group.fw_update_ifc.ctam_stage_fw(partial=1, image_type="corrupt"):
+            status, status_msg, task_id = self.group.fw_update_ifc.ctam_stage_fw(partial=1, image_type="corrupt")
+            if status:
                 step1.add_log(
                     LogSeverity.INFO,
                     f"{self.test_id} : FW Update Staged Initiation Failed as Expected",

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_empty_metadata_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_empty_metadata_image_update.py
@@ -85,9 +85,9 @@ class CTAMTestNegativeEmptyMetadataImageUpdate(TestCase):
 
         step3 = self.test_run().add_step(f"{self.__class__.__name__} run(), step3_{corrupted_component_list[0]}")  # type: ignore
         with step3.scope():
-            if self.group.fw_update_ifc.ctam_stage_fw(
-                partial=1, image_type="empty_metadata", corrupted_component_id=corrupted_component_id
-            ):
+            status, status_msg, task_id = self.group.fw_update_ifc.ctam_stage_fw(partial=1, image_type="empty_metadata", 
+                                                                                 corrupted_component_id=corrupted_component_id)
+            if status:
                 step3.add_log(
                     LogSeverity.INFO,
                     f"{self.test_id} : FW Update Stage Initiation Failed as Expected",

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_full_device_update_staging_interruption_with_ac_reset.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_full_device_update_staging_interruption_with_ac_reset.py
@@ -78,9 +78,8 @@ class CTAMTestFullDeviceUpdateInterruptionWithSingleDeviceUpdate(TestCase):
 
         step2 = self.test_run().add_step(f"{self.__class__.__name__} run(), step2")  # type: ignore
         with step2.scope():
-            fwupd_status, fwupd_task_id = self.group.fw_update_ifc.ctam_stage_fw(image_type="backup", 
-                                                                                 wait_for_stage_completion=False,
-                                                                                 return_task_id=True)
+            fwupd_status, _, fwupd_task_id = self.group.fw_update_ifc.ctam_stage_fw(image_type="backup", 
+                                                                                 wait_for_stage_completion=False)
             if fwupd_status:
                 step2.add_log(LogSeverity.INFO, f"{self.test_id} : FW Update Staged")
             else:
@@ -105,7 +104,8 @@ class CTAMTestFullDeviceUpdateInterruptionWithSingleDeviceUpdate(TestCase):
                     if result:
                         step2_device = self.test_run().add_step(f"{self.__class__.__name__} run(), step2_{device}")  # type: ignore
                         with step2_device.scope():
-                            if self.group.fw_update_ifc.ctam_stage_fw(partial=1):
+                            status, _, _ = self.group.fw_update_ifc.ctam_stage_fw(partial=1)
+                            if status:
                                 step2_device.add_log(LogSeverity.INFO, f"{self.test_id} : FW Update Staged - Unexpected")
                                 result = False
                             else:

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_device_uuid_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_device_uuid_image_update.py
@@ -70,9 +70,9 @@ class CTAMTestNegativeInvalidDeviceUUIDImageUpdate(TestCase):
         result = True
         step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
         with step1.scope():
-            if self.group.fw_update_ifc.ctam_stage_fw(
-                partial=1, image_type="invalid_device_uuid"
-            ):
+            status, status_msg, task_id = self.group.fw_update_ifc.ctam_stage_fw(partial=1, 
+                                                                                 image_type="invalid_device_uuid")
+            if status:
                 step1.add_log(
                     LogSeverity.INFO,
                     f"{self.test_id} : FW Update Stage Initiation Failed as Expected",

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_package_uuid_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_package_uuid_image_update.py
@@ -70,9 +70,9 @@ class CTAMTestNegativeInvalidPackageUUIDImageUpdate(TestCase):
         result = True
         step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
         with step1.scope():
-            if self.group.fw_update_ifc.ctam_stage_fw(
-                partial=1, image_type="invalid_pkg_uuid"
-            ):
+            status, status_msg, task_id = self.group.fw_update_ifc.ctam_stage_fw(partial=1, 
+                                                                                 image_type="invalid_pkg_uuid")
+            if status:
                 step1.add_log(
                     LogSeverity.INFO,
                     f"{self.test_id} : FW Update Stage Initiation Failed as Expected",

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_signed_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_signed_image_update.py
@@ -71,9 +71,9 @@ class CTAMTestNegativeInvalidSignedImageUpdate(TestCase):
         result = True
         step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
         with step1.scope():
-            if self.group.fw_update_ifc.ctam_stage_fw(
-                partial=1, image_type="invalid_sign"
-            ):
+            status, status_msg, task_id = self.group.fw_update_ifc.ctam_stage_fw(partial=1, 
+                                                                                 image_type="invalid_sign")
+            if status:
                 step1.add_log(
                     LogSeverity.INFO,
                     f"{self.test_id} : FW Update Stage Initiation Failed as Expected",

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_large_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_large_image_update.py
@@ -69,7 +69,8 @@ class CTAMTestNegativeLargeImageUpdate(TestCase):
         result = True
         step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
         with step1.scope():
-            if self.group.fw_update_ifc.ctam_stage_fw(partial=1, image_type="large"):
+            status, status_msg, task_id = self.group.fw_update_ifc.ctam_stage_fw(partial=1, image_type="large")
+            if status:
                 step1.add_log(
                     LogSeverity.INFO,
                     f"{self.test_id} : FW Update Stage Initiation Failed as Expected",

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_single_fw_update_staging_interruption_with_ac_reset.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_single_fw_update_staging_interruption_with_ac_reset.py
@@ -91,7 +91,8 @@ class CTAMTestSingleFWUpdateStagingInterruptionWithACReset(TestCase):
         if result:
             step3 = self.test_run().add_step(f"{self.__class__.__name__} run(), step3")  # type: ignore
             with step3.scope():
-                if self.group.fw_update_ifc.ctam_stage_fw(partial=1, wait_for_stage_completion=False, image_type="backup"):
+                status, status_msg, task_id = self.group.fw_update_ifc.ctam_stage_fw(partial=1, wait_for_stage_completion=False, image_type="backup")
+                if status:
                     step3.add_log(LogSeverity.INFO, f"{self.test_id} : FW Update Staging Initiated")
                 else:
                     step3.add_log(LogSeverity.ERROR, f"{self.test_id} : FW Update Stage Initiation Failed")

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_unsigned_bundle_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_unsigned_bundle_update.py
@@ -71,7 +71,8 @@ class CTAMTestNegativeUnsignedBundleUpdate(TestCase):
         result = True
         step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
         with step1.scope():
-            if self.group.fw_update_ifc.ctam_stage_fw(partial=1, image_type="unsigned_bundle"):
+            status, status_msg, task_id = self.group.fw_update_ifc.ctam_stage_fw(partial=1, image_type="unsigned_bundle")
+            if status:
                 step1.add_log(
                     LogSeverity.INFO,
                     f"{self.test_id} : FW Update Stage Initiation Failed as Expected",

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_unsigned_component_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_unsigned_component_image_update.py
@@ -70,7 +70,8 @@ class CTAMTestNegativeUnsignedImageUpdate(TestCase):
         result = True
         step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
         with step1.scope():
-            if self.group.fw_update_ifc.ctam_stage_fw(partial=1, image_type="unsigned_component_image"):
+            status, status_msg, task_id = self.group.fw_update_ifc.ctam_stage_fw(partial=1, image_type="unsigned_component_image")
+            if status:
                 step1.add_log(
                     LogSeverity.INFO,
                     f"{self.test_id} : FW Update Stage Initiation Failed as Expected",

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_update_with_illegal_targets.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_update_with_illegal_targets.py
@@ -96,7 +96,8 @@ class CTAMTestNegativeUpdateWithIllegalTargets(TestCase):
         if result:
             step3 = self.test_run().add_step(f"{self.__class__.__name__} run(), step3")  # type: ignore
             with step3.scope():
-                if self.group.fw_update_ifc.ctam_stage_fw(partial=1):
+                status, status_msg, task_id = self.group.fw_update_ifc.ctam_stage_fw(partial=1)
+                if status:
                     step3.add_log(LogSeverity.INFO, f"{self.test_id} : FW Update Staged")
                 else:
                     step3.add_log(

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_single_device_update_ping_pong.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_single_device_update_ping_pong.py
@@ -99,7 +99,8 @@ class CTAMTestSingleDeviceUpdatePingPong(TestCase):
             if result:
                 step3 = self.test_run().add_step(f"{self.__class__.__name__} run(), step3_{i}")  # type: ignore
                 with step3.scope():
-                    if self.group.fw_update_ifc.ctam_stage_fw(partial=1, image_type=image_t):
+                    status, status_msg, task_id = self.group.fw_update_ifc.ctam_stage_fw(partial=1, image_type=image_t)
+                    if status:
                         step3.add_log(LogSeverity.INFO, f"{self.test_id} : FW Update Staged")
                     else:
                         step3.add_log(LogSeverity.ERROR, f"{self.test_id} : FW Update Stage Failed")

--- a/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_full_device_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_full_device_update.py
@@ -78,7 +78,8 @@ class CTAMTestFullDeviceUpdate(TestCase):
 
         step2 = self.test_run().add_step(f"{self.__class__.__name__} run(), step2")  # type: ignore
         with step2.scope():
-            if self.group.fw_update_ifc.ctam_stage_fw():
+            status, status_msg, task_id = self.group.fw_update_ifc.ctam_stage_fw()
+            if status:
                 step2.add_log(LogSeverity.INFO, f"{self.test_id} : FW Update Staged")
             else:
                 step2.add_log(

--- a/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_install_same_image_two_times.py
+++ b/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_install_same_image_two_times.py
@@ -85,7 +85,8 @@ class CTAMTestInstallSameImageTwoTimes(TestCase):
             for i in range(times):
                 step2 = self.test_run().add_step(f"{self.__class__.__name__} run(), step2")  # type: ignore
                 with step2.scope():
-                    if self.group.fw_update_ifc.ctam_stage_fw():
+                    status, status_msg, task_id = self.group.fw_update_ifc.ctam_stage_fw()
+                    if status:
                         step2.add_log(
                             LogSeverity.INFO, f"{self.test_id} : FW Update Staged"
                         )

--- a/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_single_device_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_single_device_update.py
@@ -92,7 +92,8 @@ class CTAMTestSingleDeviceUpdate(TestCase):
 
                 step3 = self.test_run().add_step(f"{self.__class__.__name__} run(), step3_{device}")  # type: ignore
                 with step3.scope():
-                    if self.group.fw_update_ifc.ctam_stage_fw(partial=1):
+                    status, status_msg, task_id = self.group.fw_update_ifc.ctam_stage_fw(partial=1)
+                    if status:
                         step3.add_log(LogSeverity.INFO, f"{self.test_id} : FW Update Staged")
                     else:
                         step3.add_log(

--- a/json_spec/input/redfish_response.json
+++ b/json_spec/input/redfish_response.json
@@ -1,0 +1,3 @@
+{
+    "UpdateProgress":"UpdateInProgress"
+}

--- a/json_spec/input/redfish_response.json
+++ b/json_spec/input/redfish_response.json
@@ -1,3 +1,0 @@
-{
-    "UpdateProgress":"UpdateInProgress"
-}

--- a/json_spec/input/redfish_response_messages.json
+++ b/json_spec/input/redfish_response_messages.json
@@ -1,0 +1,3 @@
+{
+    "UpdateProgress_Message":"UpdateInProgress"
+}


### PR DESCRIPTION
1. Enhanced code for reusing monitor task
2. Enhanced code for return types in stage_fw method
3. Changed every fw test case to use latest stage_fw method
4. Created a method to check every task created by stage fw
5. Changed flow for F8 Test case for unexpected message
6. Added redfish response message file for checking particular response message