### PR TITLE
Developer msft (emergency changes)

### DIFF
--- a/ctam/interfaces/comptool_dut.py
+++ b/ctam/interfaces/comptool_dut.py
@@ -92,6 +92,7 @@ class CompToolDut(Dut):
             self.connection_ip_address
         )
         self.multipart_form_data = redfish_uri_config.get("GPU", {}).get("MultiPartFormData", False)
+        self.multipart_push_uri_support = redfish_uri_config.get("GPU", {}).get("MultiPartPushUriSupport", False)
         self.binded_port = None
         self.SSHTunnelRemoteIPAddress = None
         self.ssh_tunnel_required = config["properties"].get("SSHTunnel", {}).get("value", False)

--- a/ctam/interfaces/fw_update_ifc.py
+++ b/ctam/interfaces/fw_update_ifc.py
@@ -178,7 +178,6 @@ class FWUpdateIfc(FunctionalIfc, metaclass=Meta):
         if self.dut().is_debug_mode():
             self.test_run().add_log(LogSeverity.DEBUG, f"URI : {uri}")
             self.test_run().add_log(LogSeverity.DEBUG, f"Targets : {targets}")
-        
         JSONData = self.RedFishFWUpdate(JSONFWFilePayload, uri, targets=targets, is_multipart=is_multipart)
         StagingStartTime = time.time()
 
@@ -347,7 +346,7 @@ class FWUpdateIfc(FunctionalIfc, metaclass=Meta):
             redfish_str="{BaseURI}/UpdateService", component_type="GPU"
         )
         response = self.dut().run_redfish_command(uri=uri, mode="GET")
-        if 'MultipartHttpPushUri' in response.dict:
+        if 'MultipartHttpPushUri' in response.dict and self.dut().multipart_push_uri_support:
             return True, response.dict['MultipartHttpPushUri'], True
         
         elif 'HttpPushUri' in response.dict:

--- a/ctam/interfaces/fw_update_ifc.py
+++ b/ctam/interfaces/fw_update_ifc.py
@@ -349,8 +349,10 @@ class FWUpdateIfc(FunctionalIfc, metaclass=Meta):
         response = self.dut().run_redfish_command(uri=uri, mode="GET")
         if 'MultipartHttpPushUri' in response.dict:
             return True, response.dict['MultipartHttpPushUri'], True
+        
         elif 'HttpPushUri' in response.dict:
-            return True, response.dict['HttpPushUri'], False
+            # return True, response.dict['HttpPushUri'], False
+            return True, uri, False  #FIXME Once we have product compliance, we will uncomment the above line. 
         return False, "", False
 
     def ctam_pushtargets(self, targets=[], is_multipart_uri=False):

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_ping_pong.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_ping_pong.py
@@ -70,7 +70,7 @@ class CTAMTestFullDeviceUpdatePingPong(TestCase):
         loops = 2
 
         for i in range(loops):
-            image_t = "default" if i % 2 == 0 else "backup"
+            image_t = "backup" if i % 2 == 0 else "default"
             if result:
                 step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
                 with step1.scope():
@@ -133,14 +133,14 @@ class CTAMTestFullDeviceUpdatePingPong(TestCase):
                         )
                         result = False
 
-            # ensure setting of self.result and self.score prior to calling super().run()
-            self.result = TestResult.PASS if result else TestResult.FAIL
-            if self.result == TestResult.PASS:
-                self.score = self.score_weight
+        # ensure setting of self.result and self.score prior to calling super().run()
+        self.result = TestResult.PASS if result else TestResult.FAIL
+        if self.result == TestResult.PASS:
+            self.score = self.score_weight
 
-            # call super last to log result and score
-            super().run()
-            return self.result
+        # call super last to log result and score
+        super().run()
+        return self.result
 
     def teardown(self):
         """

--- a/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_install_same_image_two_times.py
+++ b/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_install_same_image_two_times.py
@@ -81,21 +81,25 @@ class CTAMTestInstallSameImageTwoTimes(TestCase):
                     LogSeverity.INFO, f"{self.test_id} : FW Update Not Required"
                 )
 
-        if result:
-            for i in range(times):
-                step2 = self.test_run().add_step(f"{self.__class__.__name__} run(), step2")  # type: ignore
-                with step2.scope():
-                    status, status_msg, task_id = self.group.fw_update_ifc.ctam_stage_fw()
-                    if status:
-                        step2.add_log(
-                            LogSeverity.INFO, f"{self.test_id} : FW Update Staged"
-                        )
-                    else:
-                        step2.add_log(
-                            LogSeverity.FATAL,
-                            f"{self.test_id} : FW Update Staged Failed",
-                        )
-                        result = False
+        for i in range(times):
+            step2 = self.test_run().add_step(f"{self.__class__.__name__} run(), step2")  # type: ignore
+            if not result:
+                step2.add_log(
+                        LogSeverity.INFO, f"{self.test_id} : FW Update Staging Failed for {i}"
+                    )
+                break
+            with step2.scope():
+                status, status_msg, task_id = self.group.fw_update_ifc.ctam_stage_fw()
+                if status:
+                    step2.add_log(
+                        LogSeverity.INFO, f"{self.test_id} : FW Update Staged"
+                    )
+                else:
+                    step2.add_log(
+                        LogSeverity.FATAL,
+                        f"{self.test_id} : FW Update Staged Failed",
+                    )
+                    result = False
 
         if result:
             step3 = self.test_run().add_step(f"{self.__class__.__name__} run(), step3")  # type: ignore

--- a/json_spec/input/redfish_uri_config.json
+++ b/json_spec/input/redfish_uri_config.json
@@ -26,6 +26,7 @@
         "specific_targets": "",
 		"MultiPartFormData": false,
         "MultiPartForceUpdate": false,
+        "MultiPartPushUriSupport": false,
         "TaskServiceURI": "/TaskService/Tasks/"
     },
     "BMC": {


### PR DESCRIPTION
1. Emergency fixes for supporting platforms that do not have multiparthttppushuri support. 
2. Added a qualifier in json spec under redfish_uri_config for multipart support --> default is false (since most platforms available today not support it). In the future this will default to true.  
3. Changed the order while running ping pong test case : N--> N-1 -->N
4. We now exit if F16 (image copy twice) fails early. 