### PR TITLE
Add consolidate report feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Before you begin, ensure you have met the following requirements:
     - Python virtualenv and pip is installed
     - Install some key libraries:
          sudo apt-get install python3-tk sshpass jq
-    - Docker is installed (Skip unless you want to create a binary)    
+    - Docker is installed (Skip unless you want to create a binary). Please refer to docker.md file for docker set-up instructions.    
 
 
 ### Setup 

--- a/ctam/ctam.py
+++ b/ctam/ctam.py
@@ -81,6 +81,12 @@ def parse_args():
         help="Display current version of ctam",
         action="store_true",
     )
+    parser.add_argument(
+        "-c",
+        "--consolidate", 
+        help="Path to the previous test report for consolidation",
+        nargs="+",
+    )
     return parser.parse_args()
 
 def get_exception_details(exec: Exception = ""):
@@ -173,7 +179,8 @@ def main():
             return 1, None, "Missing required files"
         print(f"Version : {__version__}")
         print(f"WorkSpace : {args.workspace}")
-        
+        if args.consolidate:
+            print(f"Test report paths : {args.consolidate}")
         
         # NOTE: Added to read default config file is its not present in workspace directory.
         # NOTE: Only .netrc and dut_info is required to run anything other than listing all the test cases.
@@ -241,6 +248,24 @@ def main():
             )
             status_code, exit_string = runner.get_system_details()
             return status_code, None, exit_string
+        
+        elif args.consolidate:
+            runner = TestRunner(
+                workspace_dir=args.workspace,
+                logs_output_dir=logs_output_dir,
+                test_hierarchy=test_hierarchy,
+                test_runner_json_file=test_runner_json,
+                dut_info_json_file=dut_info_json,
+                package_info_json_file=package_info_json,
+                redfish_uri_config_file=redfish_uri_config,
+                redfish_response_messages=redfish_response_messages,
+                default_config_path=default_config_path,
+                consolidate = args.consolidate,
+                net_rc=net_rc,
+            )
+            status_code, exit_string = runner.consolidate_run()
+            return status_code, None, exit_string
+        
 
         elif args.testcase:
             runner = TestRunner(
@@ -298,6 +323,8 @@ def main():
                 net_rc=net_rc,
                 sequence_group_override=args.group_sequence,
             )
+        
+        
         else:
             all_tests = test_hierarchy.get_all_tests()
             runner = TestRunner(

--- a/ctam/interfaces/comptool_dut.py
+++ b/ctam/interfaces/comptool_dut.py
@@ -88,6 +88,9 @@ class CompToolDut(Dut):
         self.connection_ip_address = config["properties"]["ConnectionIPAddress"][
             "value"
         ]
+        self.connection_port = config["properties"]["ConnectionPort"][
+            "value"
+        ]
         self.default_prefix = self.uri_builder.format_uri(redfish_str="{BaseURI}", component_type="GPU")
         self.port_list = config["properties"]["SSHTunnelPortList"]["value"]
         self.protocol = config["properties"]["SSHTunnelProtocol"]["value"]
@@ -96,7 +99,7 @@ class CompToolDut(Dut):
             self.connection_ip_address
         )
         self.multipart_form_data = redfish_uri_config.get("GPU_FWUpdate", {}).get("MultiPartFormData", False)
-        self.multipart_push_uri_support = redfish_uri_config.get("GPU", {}).get("MultiPartPushUriSupport", False)
+        self.multipart_push_uri_support = redfish_uri_config.get("GPU_FWUpdate", {}).get("MultiPartPushUriSupport", False)
         self.binded_port = None
         self.SSHTunnelRemoteIPAddress = None
         self.ssh_tunnel_required = config["properties"].get("SSHTunnel", {}).get("value", False)
@@ -137,6 +140,8 @@ class CompToolDut(Dut):
             self.__user_name, _, self.__user_pass = self.net_rc.authenticators(
                 self.SSHTunnelRemoteIPAddress
             )
+        else:
+            self.connection_ip_address = f"{self.connection_ip_address}:{self.connection_port}"
         
         # TODO investigate storing FW update files via add_software_info() in super
         self.__connection_url = f"{self.protocol}://{self.connection_ip_address}"
@@ -219,7 +224,7 @@ class CompToolDut(Dut):
                     "Path": filename,
                     "LineNo": lineno,
                     "RequestHeaders": headers if headers is not None else "{}",
-                    "RequestBody": body if body is not None else "{}",
+                    "RequestBody": body if (body is not None) and isinstance(body, dict) else "{}",
             }
             kwargs = {"path": uri, "headers": headers}
             if timeout is not None:
@@ -262,8 +267,7 @@ class CompToolDut(Dut):
                 msg.update({
                     "ResponseCode": response.status,
                     "Response":responseData, # FIXME: self-test report cannot be converted to dict # FIXED: Throws error in some cases when response.dict is used and the response body is empty
-                    })
-                
+                    }) 
             elif response.status in range (200,204):
                 msg.update({
                     "ResponseCode": response.status,
@@ -320,7 +324,7 @@ class CompToolDut(Dut):
                     "Path": filename,
                     "LineNo": lineno,
                     "RequestHeaders": headers if headers is not None else "{}",
-                    "RequestBody": body if body is not None else "{}",
+                    "RequestBody": body if (body is not None) and isinstance(body, dict) else "{}",
             }
             url = self.connection_url + uri
             kwargs = {"path": uri, "headers": headers}

--- a/ctam/interfaces/comptool_dut.py
+++ b/ctam/interfaces/comptool_dut.py
@@ -254,13 +254,16 @@ class CompToolDut(Dut):
             if response.status in range (200,204) and response.text: # FIXME: Add error handling in case the request fails
                 responseData = None
                 try:
-                    responseData = response.dict
+                    import ast
+                    data = ast.literal_eval(response.text) # Convert response text to a Python dictionary
+                    responseData = response.dict # Get the response data as a dictionary
                 except Exception as e:
-                    responseData = response.text
+                    responseData = response.text # If conversion fails, use the raw response text
                 msg.update({
                     "ResponseCode": response.status,
                     "Response":responseData, # FIXME: self-test report cannot be converted to dict # FIXED: Throws error in some cases when response.dict is used and the response body is empty
-                    }) 
+                    })
+                
             elif response.status in range (200,204):
                 msg.update({
                     "ResponseCode": response.status,

--- a/ctam/interfaces/functional_ifc.py
+++ b/ctam/interfaces/functional_ifc.py
@@ -678,7 +678,7 @@ class FunctionalIfc:
             
             dt = datetime.now().strftime("%m_%d_%Y_%H_%M_%S")
             dump_tarball_path = os.path.join( 
-                    self.dut().workspace_dir,
+                    self.dut().workspace_dir,self.dut().logger_path,
                     "{}_dump.tar.xz".format(dt))
             
             response =  self.dut().run_redfish_command(uri=URL)
@@ -689,7 +689,7 @@ class FunctionalIfc:
                 import tarfile
                 dump = tarfile.open(dump_tarball_path)
                 DumpPath = os.path.join( 
-                    self.dut().workspace_dir, 
+                    self.dut().workspace_dir,self.dut().logger_path,
                     "{}_dump".format(dt))
                 dump.extractall(DumpPath) # This will create a directory if it's not present already.
                 dump.close()

--- a/ctam/interfaces/fw_update_ifc.py
+++ b/ctam/interfaces/fw_update_ifc.py
@@ -131,6 +131,9 @@ class FWUpdateIfc(FunctionalIfc, metaclass=Meta):
                             if not Package_Version:
                                 msg += "Not in the PLDM bundle"
                             
+                            elif element["Id"] in self.dut().redfish_uri_config.get("GPU_FWUpdate", {}).get("exclude_targets_list", []):
+                                msg += "Skipping as it is in the exclude list"
+                            
                             elif element["Version"] not in Package_Version and (
                                 self.included_targets == []
                                 or element["@odata.id"] in self.included_targets
@@ -147,8 +150,8 @@ class FWUpdateIfc(FunctionalIfc, metaclass=Meta):
                         # Not in HttpPushURITargets
                         pass
             except Exception as e:
-                failure_reason += msg + " Exception occured: " + str(e)
-                self.test_run().add_log(LogSeverity.ERROR, msg + "Exception occured: " + str(e))
+                failure_reason += " Exception occured: " + str(e)
+                self.test_run().add_log(LogSeverity.ERROR, "Exception occured: " + str(e))
                 VersionsDifferent = False
                 
         return VersionsDifferent, failure_reason
@@ -321,9 +324,13 @@ class FWUpdateIfc(FunctionalIfc, metaclass=Meta):
         # Verify version of components currently reporting in FW inventory
         for element in self.PostInstallDetails:
             try:
+                if element["Id"] in self.dut().redfish_uri_config.get("GPU_FWUpdate", {}).get("exclude_targets_list", []):
+                    msg = f"Skipping {element['Id']} as it is in the exclude list"
+                    self.test_run().add_log(LogSeverity.DEBUG, msg)
+                    continue
                 negative_case = (
                     image_type == "negate" 
-                    or str(element["Updateable"]) == "False" # Note, this may mean empty SoftwareId. So this condition needs to come before the next one
+                    or str(element["Updateable"]).lower() == "false" # Note, this may mean empty SoftwareId. So this condition needs to come before the next one
                     or (image_type == "corrupt_component" and int(element["SoftwareId"], 16) == int(corrupted_component_id, 16) )
                     or (self.included_targets != []
                         and element["@odata.id"] not in self.included_targets)

--- a/ctam/test_runner.py
+++ b/ctam/test_runner.py
@@ -657,6 +657,32 @@ class TestRunner:
                     except Exception as e:
                         print(f"Error reading {full_path}: {e}")
 
+        # Check for Duplicate TestID's
+        filtered_list = []
+        # Dictionary to store result for unique TestID
+        filtered_data = {}
+        # For the repeated TestID's create only one entry with result as FAIL if
+        # any one of the result in the repeated TestID fails.
+        for record in test_score_data:
+            test_id = record['TestID']
+            # convert the execution time to float
+            exec_time = float(record['ExecutionTime'].split()[0])
+            test_result = record['TestCaseResult']
+
+            #if the test ID not available before then add it
+            if test_id not in filtered_data:
+                filtered_data[test_id] = record
+            else:
+                # If the current record has FAIL and has higher execution time then replace it
+                existing_record = filtered_data[test_id]
+                existing_exec_time = float(existing_record['ExecutionTime'].split()[0])
+                if (test_result == "FAIL"):
+                    if existing_record['TestCaseResult'] != "FAIL" or exec_time > existing_exec_time:
+                        filtered_data[test_id] = record
+
+        # Convert the dictionary values back to a list and assign it back to test_score_data
+        test_score_data = list(filtered_data.values())
+
         # Save the consolidated cleaned JSON data into a single JSON file
         with open(consolidated_output_json, "w", encoding="utf-8") as out_f:
             json.dump(test_score_data, out_f, indent=4)

--- a/ctam/test_runner.py
+++ b/ctam/test_runner.py
@@ -8,6 +8,7 @@ LICENSE file in the root directory of this source tree.
 """
 from pathlib import Path
 import os
+import re
 import json
 import netrc
 import platform
@@ -58,6 +59,7 @@ class TestRunner:
         redfish_response_messages,
         default_config_path,
         net_rc,
+        consolidate = None,
         single_test_override=None,
         sequence_test_override=None,
         single_group_override=None,
@@ -95,11 +97,15 @@ class TestRunner:
         self.test_groups = []
         self.group_sequence = []
         self.test_result_data = []
+        self.consolidate_data = []
         self.total_cases = 0        
         self.output_dir = logs_output_dir
         self.workspace_dir = workspace_dir
+        self.consolidate = consolidate
         self.response_check_name = None
         self.compliance_data = {}
+        self.consolidate_compliance_data = {}
+        self.inside = False
         self.include_tags_set = set()
         self.exclude_tags_set = set()
         self.weighted_scores = {}
@@ -515,6 +521,178 @@ class TestRunner:
             self.post_proces_logs(self.writer.log_file)
             return status_code, exit_string
         
+    def consolidate_run(self):
+        """
+        Consolidates test results from multiple JSON files and generates a final consolidated report.
+        """
+        try:
+            status_code = 0
+            exit_string = "Test consolidation completed successfully"
+            
+            if self.consolidate:
+                self.inside = True
+                
+                # Generate a timestamped log filename for better tracking
+                timestamp = datetime.now().strftime("%m_%d_%Y_%H_%M_%S")
+                log_filename = f"TestReport_consolidated_{timestamp}.log"
+                output_file  = os.path.join(self.output_dir, log_filename)
+                
+                # Generate a timestamped json filename for better tracking
+                log_json_name = f"TestScore_consolidated_{timestamp}.json"
+                consolidated_output_json  = os.path.join(self.output_dir, log_json_name)
+                
+                # Initialize variables for summary calculations
+                self.test_result_file = output_file
+                total_execution_time = timedelta()
+                total_score_weight = 0
+                total_score = 0
+                grade = ""
+                
+                # Retrieve compliance test cases
+                data = self.test_hierarchy.get_compliance_test_cases()
+                
+                # Normalize compliance scores if required
+                if self.normalized_scores:
+                    self.comp_data = self.generate_normalized_compliance_data(data, "")
+                
+                # Consolidate all test score JSONs into one
+                log_paths = self.consolidate  #self.consolidate` contains the list of folders
+                self.get_consolidated_test_scores(log_paths, consolidated_output_json)  # Now cleans and consolidates the JSON files
+                
+                with open(consolidated_output_json, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+                    
+                # Process each test entry from JSON
+                for entry in data:
+                    if "TestID" in entry:  # Identify test case entries
+                        test_id = entry["TestID"]
+                        test_name = entry["TestName"]
+                        
+                        # Convert execution time string to timedelta
+                        try:
+                            exec_time_sec = float(entry["ExecutionTime"].split()[0])  # Extract time in seconds
+                            exec_time = timedelta(seconds=exec_time_sec)  
+                        except ValueError:
+                            print(f"Skipping entry with invalid ExecutionTime: {entry}")
+                            continue
+                        
+                        # Extract test scores and results
+                        score_weight = float(entry.get("TestCaseScoreWeight", 0) or 0)
+                        test_score = float(entry.get("TestCaseScore", 0) or 0)
+                        result = entry.get("TestCaseResult", "UNKNOWN")
+                        
+                        # Retrieve test instances from the hierarchy
+                        group_instance, test_case_instances = self.test_hierarchy.instantiate_obj_for_testcase(test_id)
+                        
+                        for test_instance in test_case_instances:
+                            if self.weighted_scores:
+                                self.__compliance_level_score(testcase=test_instance)
+                            
+                            # Determine if the test case passed (1 for "PASS", 0 otherwise)
+                            t_pass = 1 if result == "PASS" else 0
+                            
+                            # Update scores based on configurations
+                            if self.weighted_scores:
+                                self.update_weighted_data(test_instance, exec_time, t_pass, test_score)
+                            if self.normalized_scores:
+                                self.update_normalized_compliance_data(test_instance, t_pass, exec_time)
+                            
+                        # Store processed data
+                        self.consolidate_data.append((test_id, test_name, exec_time, score_weight, test_score, result))
+                        
+                        # Accumulate total execution time, weight, and score
+                        total_execution_time += exec_time
+                        total_score_weight += score_weight
+                        total_score += test_score
+            
+                # Calculate overall test grade percentage
+                if total_score_weight > 0:
+                    grade = f"{(total_score / total_score_weight) * 100:.1f}%"
+                
+                # Append final total row
+                self.consolidate_data.append(("Total", "", total_execution_time, total_score_weight, total_score, grade))
+                self.test_result_file = output_file
+                
+                # Generate various reports
+                self.generate_domain_test_report()
+                self.generate_compliance_level_test_report()
+                if self.normalized_scores:
+                    self.normalized_compliance_level_table()
+                self.generate_test_report()
+                
+                print(f"Consolidated log is present at: {self.test_result_file}")
+        
+        except Exception as e:
+            status_code, exit_string = 1, f"Test consolidation failed due to exception: {repr(e)}"
+        
+        return status_code, exit_string
+
+    def get_consolidated_test_scores(self,log_paths, consolidated_output_json):
+        """
+        Retrieves JSON files matching the TestScore* filename from given folder paths,
+        consolidates into a single JSON file.
+        """
+        test_score_data = []
+
+        for folder_path in log_paths:
+            if not os.path.exists(folder_path):
+                print(f"Warning: Folder not found - {folder_path}")
+                continue
+
+            for file in os.listdir(folder_path):
+                full_path = os.path.join(folder_path, file)
+                if file.startswith("TestScore") and file.endswith(".json"):
+                    try:
+                        data = self.load_fixed_json(full_path)  # Use the fixed JSON loader
+
+                        if isinstance(data, list):
+                            # Filter and keep only objects that have 'TestID'
+                            filtered_data = [entry for entry in data if "TestID" in entry]
+                            test_score_data.extend(filtered_data)
+                            
+                        # Append only valid test case entries having single test result
+                        elif isinstance(data, dict) and "TestID" in data:
+                            test_score_data.append(data)  
+                            
+                    except Exception as e:
+                        print(f"Error reading {full_path}: {e}")
+
+        # Save the consolidated cleaned JSON data into a single JSON file
+        with open(consolidated_output_json, "w", encoding="utf-8") as out_f:
+            json.dump(test_score_data, out_f, indent=4)
+
+        print(f"Consolidated JSON saved at: {consolidated_output_json}")
+    
+    def load_fixed_json(self, file_path):
+        """
+        Reads and fixes improperly formatted JSON files before parsing.
+        """
+        try:
+            with open(file_path, "r", encoding="utf-8") as file:
+                content = file.read().strip()
+
+            if not content:
+                print(f"Warning: {file_path} is empty!")
+                return []
+            
+            # Fix JSON format: Ensure it starts with '[' and ends with ']'
+            if not content.startswith("["):
+                content = "[" + content
+            if not content.endswith("]"):
+                content += "]"
+            
+            # Remove trailing commas inside the JSON
+            content = re.sub(r",\s*}", "}", content)  # Remove trailing commas in objects
+            content = re.sub(r"},\s*]", "}]", content)  # Remove trailing comma before closing bracket
+            
+            return json.loads(content)
+        
+        except json.JSONDecodeError as e:
+            print(f"Error decoding JSON in {file_path}: {e}")
+            return []
+
+    
+        
     def _run_group_test_cases(self, group_instance, test_case_instances):
         """
         for now, create a separate test run for each group. In the event of failures
@@ -687,14 +865,23 @@ class TestRunner:
                 self.comp_tool_dut.clean_up()
             return status_code, exit_string
     
-    def update_weighted_data(self, test_instance):
+    def update_weighted_data(self, test_instance , exec_time=None , t_pass=None , test_score=None):
         c_level = test_instance.compliance_level
         w_score = self.weighted_scores.get(test_instance.compliance_level, 10)
-        execution_time = test_instance.execution_time
         total_test = 1
-        test_passed = 1 if TestResult(test_instance.result).name == TestResult.PASS.name else 0
+        
+        # Use t_pass and exec_time if consolidate is True, else use the existing logic to run the testcase.
+        if self.consolidate and self.inside:
+            execution_time =  exec_time
+            test_passed = t_pass       
+        else:
+            execution_time = test_instance.execution_time
+            test_passed = 1 if TestResult(test_instance.result).name == TestResult.PASS.name else 0
+            
         score_weight = test_instance.score_weight
-        score = test_instance.score
+        
+        # Use test_score if consolidate is True, else use the existing logic to run the testcase.
+        score = test_score if (self.consolidate and self.inside) else test_instance.score
         available_testcases = self.test_hierarchy.get_compliance_test_cases()
         grade = 0
         if test_instance.compliance_level in self.weighted_scores:
@@ -704,14 +891,14 @@ class TestRunner:
             self.generate_compliance_data(test_instance, "L3", self.weighted_scores["L3"], available_testcases["L3"], total_test, test_passed, 0, 0, 0, execution_time)
 
     def generate_compliance_data(self, test_instance, c_level, l_weight, a_testcases, t_test, t_pass, s_weight, score, grade, e_time):
-        
-        if c_level not in self.compliance_data:
-            
+        # Determine which compliance data dictionary to be used if consolidation is performed.
+        compliance_data_dict = self.consolidate_compliance_data if (self.consolidate and self.inside) else self.compliance_data
+        if c_level not in compliance_data_dict:
             if s_weight == 0:
                 grade = 0
             else:
-                grade = round((test_instance.score / test_instance.score_weight * 100), 2)
-            self.compliance_data[c_level] = [c_level,
+                grade = round((score / test_instance.score_weight * 100), 2)
+            compliance_data_dict[c_level] = [c_level,
                                             l_weight,
                                             a_testcases,
                                             t_test,
@@ -722,14 +909,14 @@ class TestRunner:
                                             e_time
                                             ]
         else:
-            data = self.compliance_data[c_level]
+            data = compliance_data_dict[c_level]
             sw = data[5] + test_instance.score_weight
-            s = data[6] + test_instance.score
+            s = data[6] + score
             if s_weight == 0:
                 grade = 0
             else:
                 grade = round((s / sw * 100), 2)
-            self.compliance_data[c_level] = [c_level,
+            compliance_data_dict[c_level] = [c_level,
                                                 l_weight,
                                                 a_testcases,
                                                 data[3] + t_test,
@@ -758,26 +945,33 @@ class TestRunner:
                 "Execution Time":timedelta(seconds=0)}
         return comp_data
 
-    def update_normalized_compliance_data(self, test_instance):
+    def update_normalized_compliance_data(self, test_instance,t_pass=None, e_time=None):
         c_level = test_instance.compliance_level
         if c_level in self.comp_data:
             data = self.comp_data[c_level]
             data["TestCases Executed"] += 1
-            data["TestCases Passed"] += 1 if TestResult(test_instance.result).name == TestResult.PASS.name else 0
+            
+            # Use t_pass if consolidate is True, else use the existing logic to run the testcase.
+            data["TestCases Passed"] += t_pass if t_pass else (1 if test_instance and TestResult(test_instance.result).name == TestResult.PASS.name else 0)
             data["Total Score"] = data["Normalized Score"] * data["TestCases Passed"]
             data["Max Score"] = data["Normalized Score"] * data["TestCases Executed"]
             grade = round(data["TestCases Passed"] / data["TestCases Executed"] * 100, 2)
-            data["Execution Time"] += test_instance.execution_time
+            
+            # Use e_time if consolidate is True, else use the existing logic to run the testcase.
+            data["Execution Time"] += e_time if (self.consolidate and self.inside) else test_instance.execution_time
             data["Grade"] = grade
             self.comp_data[c_level] = data
         else:
             data = self.comp_data["L3"]
             data["TestCases Executed"] += 1
-            data["TestCases Passed"] += 1 if TestResult(test_instance.result).name == TestResult.PASS.name else 0
+            # Use t_pass if consolidate is True, else use the existing logic to run the testcase.
+            data["TestCases Passed"] += t_pass if t_pass else (1 if test_instance and TestResult(test_instance.result).name == TestResult.PASS.name else 0)
             data["Total Score"] = data["Normalized Score"] * data["TestCases Passed"]
             data["Max Score"] = data["Normalized Score"] * data["TestCases Executed"]
             # grade = round(data["TestCases Passed"] / data["TestCases Executed"] * 100, 2)
-            data["Execution Time"] += test_instance.execution_time
+            
+            # Use e_time if consolidate is True, else use the existing logic to run the testcase.
+            data["Execution Time"] += e_time if (self.consolidate and self.inside) else test_instance.execution_time
             data["Grade"] = 0
             self.comp_data["L3"] = data
 
@@ -787,11 +981,14 @@ class TestRunner:
         It will have TestID, TestName, Test Score, Test Result, Test Weight and total
 
         """
+        # Use consolidate_data if provided and not empty; otherwise, use self.test_result_data
+        test_data = self.consolidate_data if self.consolidate_data else self.test_result_data
+         
         t = PrettyTable(["Test ID", "Test Name", "Execution Time", "TestCase Weight", "Test Score", "Test Result"])
         t.title = f"Test Result -  V {__version__}"
-        t.add_rows(self.test_result_data[:len(self.test_result_data) - 1:])
+        t.add_rows(test_data[:len(test_data) - 1:])
         t.add_row(["", "", "", "", "", ""], divider=True)
-        t.add_row(self.test_result_data[-1], divider=True)
+        t.add_row(test_data[-1], divider=True)
         t.align["TestName"] = "l"
         
         with open(self.test_result_file, 'a') as f:
@@ -803,10 +1000,11 @@ class TestRunner:
         This method is used for creating a tabula format for compliance level test result.
         It will have ComplianceID, ComplianceScore, GroupID, TestCaseID, TestCaseName, WeightedScore, TestScore and TestResult.
         """
-        
+        # consolidate_compliance_data dictionary will be used if it is not empty, else use the existing logic to run the testcase.
+        compliance_dict = self.consolidate_compliance_data if self.consolidate_compliance_data else self.compliance_data
+
         if self.weighted_scores:
-        
-            c_data = dict(sorted(self.compliance_data.items()))
+            c_data = dict(sorted(compliance_dict.items()))
             compliance_values = c_data.values()
             total_test_cases = sum([x[3] for x in compliance_values])
             total_passed_test_cases = sum([x[4] for x in compliance_values])
@@ -885,12 +1083,14 @@ class TestRunner:
         passedTests = [0, 0, 0, 0]
         compScore = [0, 0, 0, 0]
         compWeight = [0, 0, 0, 0]
+        # Use consolidate_data if provided, else use self.test_result_data
+        test_data = self.consolidate_data if self.consolidate_data else self.test_result_data   
         
-        for i in range(len(self.test_result_data)-1):
-            testID = self.test_result_data[i][0]
-            testExecTime = self.test_result_data[i][2].total_seconds()
-            testWeight = self.test_result_data[i][3]
-            testScore = self.test_result_data[i][4]
+        for i in range(len(test_data)-1):
+            testID = test_data[i][0]
+            testExecTime = test_data[i][2].total_seconds()
+            testWeight = test_data[i][3]
+            testScore = test_data[i][4]
 
             # check for telemetry cases
             if testID.startswith("T"):

--- a/ctam/test_runner.py
+++ b/ctam/test_runner.py
@@ -679,6 +679,9 @@ class TestRunner:
                 if (test_result == "FAIL"):
                     if existing_record['TestCaseResult'] != "FAIL" or exec_time > existing_exec_time:
                         filtered_data[test_id] = record
+                else:
+                    if existing_record['TestCaseResult'] != "FAIL" and exec_time > existing_exec_time:
+                        filtered_data[test_id] = record
 
         # Convert the dictionary values back to a list and assign it back to test_score_data
         test_score_data = list(filtered_data.values())

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_activation_time.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_activation_time.py
@@ -8,7 +8,17 @@ LICENSE file in the root directory of this source tree.
 :Group Name:	fw_update
 :Score Weight:	10
 
-:Description:	Verify that firmware activation operation does not exceed the max time specified in the requirements.
+:Description:	This test case verifies that the firmware activation operation does not exceed the maximum time specified 
+                in the requirements. The test stages the firmware update, activates it, and verifies the update within the 
+                specified time. The activation time is checked to ensure it does not exceed the maximum allowed time 
+                (FwActivationTimeMax) as defined in the device configuration.
+
+:PASS Criteria: The test passes if the firmware activation completes within the maximum allowed time (FwActivationTimeMax) 
+                and the GPU is reachable and enabled after activation.
+
+:FAIL Criteria: The test fails if the firmware activation exceeds the maximum allowed time (FwActivationTimeMax), the GPU 
+                is not reachable or not enabled after activation, or the verification fails.
+
 :Usage 1:		python ctam.py -w ..\workspace -t F64
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Full Device Update Activation Time"
 

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_activation_with_failed_component.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_activation_with_failed_component.py
@@ -8,9 +8,19 @@ LICENSE file in the root directory of this source tree.
 :Group Name:	fw_update
 :Score Weight:	10
 
-:Description:	Firmware Update Stack Robustness Test. If one component copying (staging) fails, verify activation is handled correctly.
-                Vendor needs to provide a fwpkg where a component image is corrupted, and all other component images are good (i.e. it will not fail the update).
-                
+:Description: This test verifies the robustness of the firmware update stack when one component fails to stage. 
+              The vendor must provide a firmware package where one component image is corrupted, while all other 
+              component images are valid(If it not provided in package info testcase can generate). 
+              The test performs the following steps:
+              1. Retrieves the component to be corrupted.
+              2. Performs a firmware update pre-check.
+              3. Stages the firmware update with the corrupted component.
+              4. Activates the firmware update.
+              5. Verifies the firmware update.
+
+              PASS Criteria: The test passes if the firmware activation is handled correctly despite one component failing to stage.
+              FAIL Criteria: The test fails if the firmware activation is not handled correctly when one component fails to stage.
+
 :Usage 1:		python ctam.py -w ..\workspace -t F56
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Full Device Update Activation With Failed Component"
 

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_in_loop.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_in_loop.py
@@ -9,7 +9,12 @@ LICENSE file in the root directory of this source tree.
 :Group Name:	fw_update
 :Score Weight:	10
 
-:Description:	Test case of full firmware update in a loop. To verify the ongoing rollback is not affected by subsequent update.
+:Description:	This test case performs a full firmware update in a loop to ensure stability and verify that ongoing rollbacks are not affected by subsequent updates.
+                The test stages the firmware update, activates it, and verifies the update in a loop.
+
+                PASS Criteria: The test passes if N-1 & N firmware updates complete successfully without errors in the loop.
+                FAIL Criteria: The test fails if any firmware update encounters an error in the loop.
+
 :Usage 1:		python ctam.py -w ..\workspace -t F8
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Full Device Update In Loop"
 

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_ping_pong.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_ping_pong.py
@@ -8,7 +8,11 @@ LICENSE file in the root directory of this source tree.
 :Group Name:	fw_update
 :Score Weight:	10
 
-:Description:	This test case entails performing firmware updates in a loop between N and N-1 i.e default and backup respectively.
+:Description:	This test case entails performing firmware updates in a loop between N-1 and N i.e backup and default respectively.
+                The test ensures that the firmware updates can be performed repeatedly without issues.
+
+                PASS Criteria: The test passes if all firmware updates between backup and default complete successfully without errors.
+                FAIL Criteria: The test fails if any firmware update between backup and default encounters an error.
 
 :Usage 1:		python ctam.py -w ..\workspace -t F88
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Full Device Update Ping Pong"

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_rollback.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_rollback.py
@@ -8,7 +8,15 @@ LICENSE file in the root directory of this source tree.
 :Group Name:	fw_update
 :Score Weight:	10
 
-:Description:	Basic test case of full firmware update.To verify the successful execution of a full firmware update process.
+:Description:	This test case verifies the successful execution of a full firmware update process, focusing on the backup image (N-1). 
+                It ensures that the firmware update is staged, activated, and verified without errors.
+
+                PASS Criteria: 
+                    - The test passes if the firmware update completes successfully and the backup image is activated and is verified.
+                
+                FAIL Criteria: 
+                    - The test fails if the firmware update or verification encounters an error.
+
 :Usage 1:		python ctam.py -w ..\workspace -t F0
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Full Device Update Rollback"
 

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_staging_time.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_staging_time.py
@@ -8,7 +8,16 @@ LICENSE file in the root directory of this source tree.
 :Group Name:	fw_update
 :Score Weight:	10
 
-:Description:	Verify that firmware copy operation (staging) does not exceed the max time specified in the requirements.
+Description:	
+    This test verifies that the firmware copy operation (staging) does not exceed the maximum time specified in the requirements(FwStagingTimeMax). 
+    The test involves performing a pre-check to ensure the device is capable of firmware updates, followed by staging the firmware update and verifying the operation's success.
+
+:PASS Criteria:	
+    - The firmware updation process should not exceed the maximum time specified in the requirements(FwStagingTimeMax).
+
+:FAIL Criteria:	
+    - The firmware staging operation fails or does not complete within the specified time(FwStagingTimeMax).
+    
 :Usage 1:		python ctam.py -w ..\workspace -t F63
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Full Device Update Staging Time"
 

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_staging_with_failed_component.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_staging_with_failed_component.py
@@ -8,9 +8,16 @@ LICENSE file in the root directory of this source tree.
 :Group Name:	fw_update
 :Score Weight:	10
 
-:Description:	Firmware Update Stack Robustness Test. If one component copying (staging) fails, verify other component copying (staging) goes through.
-                Vendor needs to provide a fwpkg where a component image is corrupted, and all other component images are good (i.e. it will not fail the update).
-                
+:Description:	
+    Firmware Update Stack Robustness Test. If one component copying (staging) fails, verify other component copying (staging) goes through.
+    Vendor needs to provide a fwpkg where a component image is corrupted (If it not provided in package info testcase can generate), and all other component images are good (i.e. it will not fail the update).
+
+:PASS Criteria:	
+    - The corrupted component staging fails, while other component staging goes through.
+
+:FAIL Criteria:	
+    - The corrupted component staging fails, as well as other component staging also fails.
+
 :Usage 1:		python ctam.py -w ..\workspace -t F55
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Full Device Update Staging With Failed Component"
 

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_with_older_version.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_with_older_version.py
@@ -8,8 +8,17 @@ LICENSE file in the root directory of this source tree.
 :Group Name: fw_update
 :Score Weight: 10
 
-:Description: This test case focuses on updating the firmware of the full device using an older or previous version
-of the current version that is already installed.
+:Description: 
+    This test case focuses on updating the firmware of the full device using an older or previous version
+    of the current version that is already installed. The objective is to ensure that the device can be
+    downgraded to a previous firmware version without issues.
+
+:PASS Criteria:	
+    - The firmware staging operation completes successfully with the older version.
+
+:FAIL Criteria:	
+    - The firmware staging operation fails or does not complete with the older version.
+
 :Usage 1: python ctam.py -w ..\workspace -t F19
 :Usage 2: python ctam.py -w ..\workspace -t "CTAM Test Full Device Update With Older Version"
 

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_with_self_test.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_with_self_test.py
@@ -8,7 +8,15 @@ LICENSE file in the root directory of this source tree.
 :Group Name:	fw_update
 :Score Weight:	10
 
-:Description:	This test case does a full firmware update first, and then verifies if self-test reports any failures.
+:Description:	
+    This test case performs a full firmware update and then verifies if the self-test reports any failures.
+
+:PASS Criteria:	
+    - The firmware update completes successfully without any failures in the self-test report.
+
+:FAIL Criteria:	
+    - The firmware update fails with failures in the self-test reports after the firmware update.
+
 :Usage 1:		python ctam.py -w ..\workspace -T F67
 :Usage 2:		python ctam.py -w ..\workspace -T "CTAM Test Full Device Update with Self-test Verification"
 

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_corrupt_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_corrupt_image_update.py
@@ -8,8 +8,16 @@ LICENSE file in the root directory of this source tree.
 :Group Name:	fw_update
 :Score Weight:	10
 
-:Description:	This test case is a Negative test. It would search for GPU_FW_IMAGE_CORRUPT referenced by package_info.json and attempt
-                firmware update using the corrupted image.
+:Description:	
+    This test case is a negative test. It searches for GPU_FW_IMAGE_CORRUPT referenced by package_info.json and attempts
+    a firmware update using the corrupted image. The objective is to ensure that the system correctly handles the corrupted
+    image and does not proceed with the update.
+
+:PASS Criteria:	
+    - The firmware staging operation fails as expected due to the corrupted image.
+
+:FAIL Criteria:	
+    - The firmware staging operation succeeds unexpectedly with the corrupted image.
 
 :Usage 1:		python ctam.py -w ..\workspace -t F23
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Negative Corrupt Image Update"

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_empty_metadata_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_empty_metadata_image_update.py
@@ -8,8 +8,16 @@ LICENSE file in the root directory of this source tree.
 :Group Name:	fw_update
 :Score Weight:	10
 
-:Description:	This test case is a Negative Test. It'll make a copy of the default FW image provided in package_info.json 
-                and clear metadata of any component in the PLDM bundle. Then it'll attempt firmware update with the fwpkg containing corrupted UUID. 
+:Description:	
+    This test case is a negative test. It makes a copy of the default FW image provided in package_info.json
+    and clears the metadata of any component in the PLDM bundle. Then it attempts a firmware update with the fwpkg containing corrupted UUID. 
+    The objective is to ensure that the system correctly handles the corrupted metadata and does not proceed with the update.
+
+:PASS Criteria:	
+    - The firmware staging operation fails as expected due to the corrupted metadata.
+
+:FAIL Criteria:	
+    - The firmware staging operation succeeds unexpectedly with the corrupted metadata.
 
 :Usage 1:		python ctam.py -w ..\workspace -t F26
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Negative Empty Metadata Image Update"

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_full_device_update_staging_interruption_with_ac_reset.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_full_device_update_staging_interruption_with_ac_reset.py
@@ -8,8 +8,19 @@ LICENSE file in the root directory of this source tree.
 :Group Name:	fw_update
 :Score Weight:	10
 
-:Description:	Before running this test case we expect to be on N image. We will do staging with N-1 image which is getting interrupted by ac
-                power reset. At least one of the components should stay on N image after ac power reset.
+:Description:	
+    This test verifies the behavior of a full device firmware update staging process when interrupted by an AC power reset.
+    The test starts with the device on the current firmware version (N image) and attempts to stage the previous firmware version (N-1 image).
+    The staging process is intentionally interrupted by an AC power reset.
+    The objective is to ensure that at least one component remains on the current firmware version (N image) after the AC power reset.
+
+:PASS Criteria:	
+    - Post activation at least one component remains on the current firmware version (N image) after the AC reset.
+
+:FAIL Criteria:	
+    - System does not boot up healthily after the AC reset.
+    - If all updateable components move to N-1 after the AC reset.
+
 :Usage 1:		python ctam.py -w ..\workspace -t F24
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Full Device Update Staging Interruption With AC Reset"
 

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_device_uuid_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_device_uuid_image_update.py
@@ -8,8 +8,16 @@ LICENSE file in the root directory of this source tree.
 :Group Name:	fw_update
 :Score Weight:	10
 
-:Description:	This test case is a Negative Test. It'll make a copy of the default FW image provided in package_info.json 
-                and corrput the UUID in all FirmwareDeviceIDRecords. Then it'll attempt firmware update with the fwpkg containing corrupted device UUIDs. 
+:Description:	
+    This test case is a negative test. It makes a copy of the default FW image provided in package_info.json 
+    and corrupts the UUID in all FirmwareDeviceIDRecords. Then it attempts a firmware update with the fwpkg containing corrupted device UUIDs. 
+    The objective is to ensure that the system correctly handles the corrupted UUIDs and does not proceed with the update.
+
+:PASS Criteria:	
+    - The firmware staging operation fails as expected due to the corrupted UUIDs.
+
+:FAIL Criteria:	
+    - The firmware staging operation succeeds unexpectedly with the corrupted UUIDs.
 
 :Usage 1:		python ctam.py -w ..\workspace -t F28
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Negative Invalid Device UUID Image Update"

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_package_uuid_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_package_uuid_image_update.py
@@ -8,8 +8,15 @@ LICENSE file in the root directory of this source tree.
 :Group Name:	fw_update
 :Score Weight:	10
 
-:Description:	This test case is a Negative Test. It'll make a copy of the default FW image provided in package_info.json 
-                and corrput the UUID of the PLDM bundle. Then it'll attempt firmware update with the fwpkg containing corrupted UUID. 
+:Description:	
+    This test case is a negative test. It makes a copy of the default FW image provided in package_info.json 
+    and corrupts the UUID of the PLDM bundle. Then it attempts a firmware update with the fwpkg containing the corrupted UUID. 
+
+:PASS Criteria:	
+    - The firmware staging operation fails as expected due to the corrupted UUID.
+
+:FAIL Criteria:	
+    - The firmware staging operation succeeds unexpectedly with the corrupted UUID.
 
 :Usage 1:		python ctam.py -w ..\workspace -t F27
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Negative Invalid Package UUID Image Update"

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_signed_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_signed_image_update.py
@@ -8,9 +8,15 @@ LICENSE file in the root directory of this source tree.
 :Group Name:	fw_update
 :Score Weight:	10
 
-:Description:	This test case focuses on the scenario where we are trying to initiate a firmware update flow with an invalid signed image. 
-				The expectation is for staging to fail when this is attempted. 
-				The image is provided by the vendor	and it has a section in package_info.json
+:Description:	
+    This test case focuses on the scenario where we are trying to initiate a firmware update flow with an invalid signed image. 
+    The expectation is for staging to fail when this is attempted. The image is provided by the vendor and it has a section in package_info.json.
+
+:PASS Criteria:	
+    - The firmware staging operation fails as expected due to the invalid signed image.
+
+:FAIL Criteria:	
+    - The firmware staging operation succeeds unexpectedly with the invalid signed image.
 
 :Usage 1:		python ctam.py -w ..\workspace -t F22
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Negative Invalid Signed Image Update"

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_large_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_large_image_update.py
@@ -8,9 +8,15 @@ LICENSE file in the root directory of this source tree.
 :Group Name:	fw_update
 :Score Weight:	10
 
-:Description:	This test case focuses on the scenario where we are trying from large image transfer is initiated for
-				a firmware update. The expectation is for staging to fail when this is attempted. The image is provided by the vendor
-				and it has a section in package_info.json
+:Description:	This test case focuses on the scenario where a large image transfer is initiated for
+				a firmware update. The expectation is for the staging process to fail when this is attempted.
+				The image is provided by the vendor and it has a section in package_info.json.
+
+				PASS Criteria:
+				- The firmware update staging process fails as expected when a large image is used.
+				
+				FAIL Criteria:
+				- The firmware update staging process succeeds unexpectedly when a large image is used.
 
 :Usage 1:		python ctam.py -w ..\workspace -t F25
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Negative Large Image Update"

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_single_device_update_with_illegal_targets.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_single_device_update_with_illegal_targets.py
@@ -8,10 +8,17 @@ LICENSE file in the root directory of this source tree.
 :Group Name:	fw_update
 :Score Weight:	10
 
-:Description:	This Test case focussed on the GPU baseboard would have multiple targets. Some of which are updatable,
-				others which are not. The goal of this test case is to identify the list of firmware inventory targets
-				that are **"not"** in the AllowableValues of the URI pointed by ``@Redfish.ActionInfo`` On attempting an
+:Description:	This test case focuses on the scenario where a GPU baseboard has multiple targets, some of which are updatable
+				and others which are not. The goal of this test case is to identify the list of firmware inventory targets
+				that are **"not"** in the AllowableValues of the URI pointed by ``@Redfish.ActionInfo``. On attempting an
 				update, we expect the firmware version to be retained.
+
+				PASS Criteria:
+				- The firmware version is retained when attempting to update targets that are not updatable.
+				
+				FAIL Criteria:
+				- The firmware version changes when attempting to update targets that are not updatable.
+
 :Usage 1:		python ctam.py -w ..\workspace -t F32
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Negative Single Device Update with illegal targets"
 

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_single_fw_update_staging_interruption_with_ac_reset.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_single_fw_update_staging_interruption_with_ac_reset.py
@@ -9,9 +9,16 @@ LICENSE file in the root directory of this source tree.
 :Score Weight:	10
 
 :Description:	This test case focuses on the scenario where an image transfer is initiated for a firmware update.
-				The objective is to ensure that after the image transfer is completed, the system proceeds without waiting
+				The objective is to ensure that after the image transfer is initiated, the system proceeds without waiting
 				for its full completion. Instead, it should immediately move on to resetting the activation flow for the full
 				firmware update process.
+
+				PASS Criteria:
+				- The system proceeds to reset the activation flow without waiting for the full completion of the image transfer.
+				
+				FAIL Criteria:
+				- The system waits for the full completion of the image transfer before proceeding to reset the activation flow.
+
 :Usage 1:		python ctam.py -w ..\workspace -t F62
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Single FW update staging interruption with AC reset"
 

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_unsigned_bundle_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_unsigned_bundle_update.py
@@ -8,9 +8,15 @@ LICENSE file in the root directory of this source tree.
 :Group Name:	fw_update
 :Score Weight:	10
 
-:Description:	This test case is a Negative test. It would search for GPU_FW_IMAGE_UNSIGNED_BUNDLE referenced by package_info.json.
+:Description:	This test case is a negative test. It searches for GPU_FW_IMAGE_UNSIGNED_BUNDLE referenced by package_info.json.
                 If the bundle is not provided, it will modify GPU_FW_IMAGE (golden fwpkg) for this test. Then it will attempt
-                firmware update using the Unsigned Bundle.
+                a firmware update using the unsigned bundle.
+
+                PASS Criteria:
+                - The firmware update staging process fails as expected when using an unsigned bundle.
+                
+                FAIL Criteria:
+                - The firmware update staging process succeeds unexpectedly when using an unsigned bundle.
 
 :Usage 1:		python ctam.py -w ..\workspace -t F90
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Negative Unsigned Bundle Update"

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_unsigned_component_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_unsigned_component_image_update.py
@@ -8,8 +8,14 @@ LICENSE file in the root directory of this source tree.
 :Group Name:	fw_update
 :Score Weight:	10
 
-:Description:	This test case is a Negative test. It would search for GPU_FW_IMAGE_UNSIGNED referenced by package_info.json and attempt
-                firmware update using the unsigned image.
+:Description:	This test case is a negative test. It searches for GPU_FW_IMAGE_UNSIGNED referenced by package_info.json and attempts
+                a firmware update using the unsigned image.
+
+                PASS Criteria:
+                - The firmware update staging process fails as expected when using an unsigned image.
+                
+                FAIL Criteria:
+                - The firmware update staging process succeeds unexpectedly when using an unsigned image.
 
 :Usage 1:		python ctam.py -w ..\workspace -t F18
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Negative Unsigned Image Update"

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_single_device_update_ping_pong.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_single_device_update_ping_pong.py
@@ -9,7 +9,13 @@ LICENSE file in the root directory of this source tree.
 :Score Weight:	10
 
 :Description:	This test case entails performing firmware updates in a loop, one device at a time but using different versions
-				for each update.
+				for each update.The test flow should go from N to N-1 image during the firmware update process.
+
+				PASS Criteria:
+				- Each firmware update completes successfully using different versions in each loop iteration.
+				
+				FAIL Criteria:
+				- Any firmware update fails during the loop iterations.
 
 :Usage 1:		python ctam.py -w ..\workspace -t F89
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Single Device Update Ping Pong"

--- a/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_full_device_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_full_device_update.py
@@ -8,7 +8,14 @@ LICENSE file in the root directory of this source tree.
 :Group Name:	fw_update
 :Score Weight:	10
 
-:Description:	Basic test case of full firmware update.To verify the successful execution of a full firmware update process.
+:Description:	Basic test case of full firmware update. This test case verifies the successful execution of a full firmware update process.
+
+                PASS Criteria:
+				- The firmware update process completes successfully and the firmware is updated to the new version.
+				
+				FAIL Criteria:
+				- The firmware update process fails or the firmware is not updated to the new version.
+    
 :Usage 1:		python ctam.py -w ..\workspace -t F1
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Full Device Update"
 

--- a/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_install_same_image_two_times.py
+++ b/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_install_same_image_two_times.py
@@ -10,6 +10,12 @@ LICENSE file in the root directory of this source tree.
 
 :Description:	This test case involves performing a full device update including verification
                 followed by repeating the update process again.
+                
+                :Pass Criteria: 
+                The test will pass if the firmware update is successfully staged, activated, and verified twice.
+
+                :Fail Criteria: 
+                The test will fail if any of the stages (staging, activation, verification) fail during either of the two updates.
 
 :Usage 1:		python ctam.py -w ..\workspace -t F16
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Install Same Image Two Times"

--- a/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_single_device_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_single_device_update.py
@@ -9,7 +9,13 @@ LICENSE file in the root directory of this source tree.
 :Score Weight:	10
 
 :Description:	Basic test case of Single Device firmware update. All updatable devices are updated and activated, one device at a time.
-                Any device fail would lead to test case fail. 
+                Any device fail would lead to test case fail.
+
+                PASS Criteria:
+                - All updatable devices are updated and activated successfully, one device at a time.
+                
+                FAIL Criteria:
+                - Any device fails to update or activate.
 
 :Usage 1:		python ctam.py -w ..\workspace -t F4
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Single Device Update"

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_logservice_dump_uri_list_read.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_logservice_dump_uri_list_read.py
@@ -8,7 +8,20 @@ LICENSE file in the root directory of this source tree.
 :Group Name:	health_check
 :Score Weight:	10
 
-:Description:	Basic test case of ensuring that there are LogServices Dump available in the accelerator
+:Description:   This test verifies the ability to read the list of dump URIs from the LogService. It performs the following steps:
+
+1. Retrieve the list of dump URIs from the LogService.
+   Example URI: /redfish/v1/Systems/{BaseboardID}/LogServices/Dump
+2. Check if the list of dump URIs is successfully retrieved.
+3. If the list of dump URIs is not retrieved, log the failure and mark the test as failed.
+4. If the list of dump URIs is successfully retrieved, mark the test as passed.
+
+PASS Criteria:
+- The list of dump URIs is successfully retrieved.
+
+FAIL Criteria:
+- The list of dump URIs is not successfully retrieved.
+
 
 :Usage 1:		python ctam.py -w ..\workspace -t H97
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test LogService Dump URI List Read"

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_logservice_uri_list_read.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_logservice_uri_list_read.py
@@ -8,7 +8,15 @@ LICENSE file in the root directory of this source tree.
 :Group Name:	health_check
 :Score Weight:	10
 
-:Description:	Basic test case of ensuring that there are LogServices available in the accelerator
+:Description:	This test case ensures that there are LogServices available in the accelerator by reading the LogServices URI list and verifying it is not empty. Additionally, it verifies the presence of specific LogServices.
+
+                PASS Criteria:
+                1. The LogServices URI list is not empty.
+                2. The presence of specific LogServices is verified successfully.
+
+                FAIL Criteria:
+                1. The LogServices URI list is empty.
+                2. The presence of specific LogServices cannot be verified.
 
 :Usage 1:		python ctam.py -w ..\workspace -t H99
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test LogServices URI List Read"

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_event_service.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_event_service.py
@@ -5,10 +5,16 @@ LICENSE file in the root directory of this source tree.
 
 :Test Name:		CTAM Test Redfish Event Service
 :Test ID:		H8
-:Group Name:	fw_update
+:Group Name:	health_check
 :Score Weight:	10
 
-:Description:	This test attempts to get event service
+:Description:	This test case attempts to get the event service and verifies its presence.
+
+                PASS Criteria:
+                1. The event service is retrieved successfully and is not empty.
+
+                FAIL Criteria:
+                1. The event service retrieval fails or returns an empty result.
 
 :Usage 1:		python ctam.py -w ..\workspace -t H8
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Redfish Event Service"

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_event_service_create_subscription.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_event_service_create_subscription.py
@@ -5,10 +5,16 @@ LICENSE file in the root directory of this source tree.
 
 :Test Name:		CTAM Test Redfish Event Service
 :Test ID:		H83
-:Group Name:	fw_update
+:Group Name:	health_check
 :Score Weight:	10
 
-:Description:	This test attempts to create event service subscription
+:Description:	This test case attempts to create an event service subscription and verifies its success.
+
+                PASS Criteria:
+                1. The event service subscription is created successfully without errors.
+
+                FAIL Criteria:
+                1. The event service subscription creation fails or returns an error.
 
 :Usage 1:		python ctam.py -w ..\workspace -t H83
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Redfish Event Service Create Subscription"

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_event_service_delete_subscription.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_event_service_delete_subscription.py
@@ -5,10 +5,16 @@ LICENSE file in the root directory of this source tree.
 
 :Test Name:		CTAM Test Redfish Event Service Delete Subscriptions
 :Test ID:		H81
-:Group Name:	fw_update
+:Group Name:	health_check
 :Score Weight:	10
 
-:Description:	This test attempts to delete event subscriptions
+:Description:	This test case attempts to delete event subscriptions and verifies its success.
+
+                PASS Criteria:
+                1. The event subscriptions are deleted successfully without errors.
+
+                FAIL Criteria:
+                1. The event subscriptions deletion fails or returns an error.
 
 :Usage 1:		python ctam.py -w ..\workspace -t H81
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Redfish Event Service Delete Subscriptions"

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_event_service_list_subscription.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_event_service_list_subscription.py
@@ -5,10 +5,16 @@ LICENSE file in the root directory of this source tree.
 
 :Test Name:		CTAM Test Redfish Event Service List Subscriptions
 :Test ID:		H80
-:Group Name:	fw_update
+:Group Name:	health_check
 :Score Weight:	10
 
-:Description:	This test attempts to get event subscriptions
+:Description:	This test case attempts to get event subscriptions and verifies their presence.
+
+                PASS Criteria:
+                1. The event subscriptions are retrieved successfully and are not empty.
+
+                FAIL Criteria:
+                1. The event subscriptions retrieval fails or returns an empty list.
 
 :Usage 1:		python ctam.py -w ..\workspace -t H80
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Redfish Event Service List Subscriptions"

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_firmware_inventory_collection.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_firmware_inventory_collection.py
@@ -8,7 +8,13 @@ LICENSE file in the root directory of this source tree.
 :Group Name:	health_check
 :Score Weight:	10
 
-:Description:	This test validates the Firmware Inventory using RIV
+:Description:	This test case validates the Firmware Inventory using the Redfish Interop Validator (RIV). It ensures that the values of the Firmware Inventory Collection are present and correct.
+
+                PASS Criteria:
+                1. The Firmware Inventory is validated successfully without errors.
+
+                FAIL Criteria:
+                1. The Firmware Inventory validation fails or returns errors.
 
 :Usage 1:		python ctam.py -w ..\workspace -t H5
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Redfish Interop Validator Firmware Inventory"

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_firmware_inventory_expanded_collection.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_firmware_inventory_expanded_collection.py
@@ -8,7 +8,15 @@ LICENSE file in the root directory of this source tree.
 :Group Name:	health_check
 :Score Weight:	10
 
-:Description:	This test attempts to get the expanded firmware inventory from update service
+:Description:	This test case attempts to get the expanded firmware inventory from the update service and verifies its presence and correctness.
+
+                PASS Criteria:
+                1. The expanded firmware inventory is retrieved successfully and is not empty.
+                2. The expanded firmware inventory is verified successfully.
+
+                FAIL Criteria:
+                1. The expanded firmware inventory retrieval fails or returns an empty result.
+                2. The expanded firmware inventory verification fails.
 
 :Usage 1:		python ctam.py -w ..\workspace -t H6
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Redfish Firmware Inventory Expanded Collection"

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_processors_expanded_collection.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_processors_expanded_collection.py
@@ -8,7 +8,15 @@ LICENSE file in the root directory of this source tree.
 :Group Name:	health_check
 :Score Weight:	10
 
-:Description:	This test attempts to get the expanded Processor inventory from update service
+:Description:	This test case attempts to get the expanded Processor inventory from the update service and verifies its presence and correctness.
+
+                PASS Criteria:
+                1. The expanded Processor inventory is retrieved successfully and is not empty.
+                2. The expanded Processor inventory is verified successfully.
+
+                FAIL Criteria:
+                1. The expanded Processor inventory retrieval fails or returns an empty result.
+                2. The expanded Processor inventory verification fails.
 
 :Usage 1:		python ctam.py -w ..\workspace -t H51
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Redfish Processor Expanded Collection"

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_software_inventory_expanded_collection.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_software_inventory_expanded_collection.py
@@ -8,7 +8,15 @@ LICENSE file in the root directory of this source tree.
 :Group Name:	health_check
 :Score Weight:	10
 
-:Description:	This test attempts to get the expanded Software inventory from update service
+:Description:	This test case attempts to get the expanded Software inventory from the update service and verifies its presence and correctness.
+
+                PASS Criteria:
+                1. The expanded Software inventory is retrieved successfully and is not empty.
+                2. The expanded Software inventory is verified successfully.
+
+                FAIL Criteria:
+                1. The expanded Software inventory retrieval fails or returns an empty result.
+                2. The expanded Software inventory verification fails.
 
 :Usage 1:		python ctam.py -w ..\workspace -t H11
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Redfish Software Inventory Expanded Collection"

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_task_service.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_task_service.py
@@ -8,7 +8,13 @@ LICENSE file in the root directory of this source tree.
 :Group Name:	health_check
 :Score Weight:	10
 
-:Description:	This test attempts to get task service
+:Description:	This test case attempts to get the task service and verifies its presence.
+
+                PASS Criteria:
+                1. The task service is retrieved successfully and is not empty.
+
+                FAIL Criteria:
+                1. The task service retrieval fails or returns an empty result.
 
 :Usage 1:		python ctam.py -w ..\workspace -t H10
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Redfish Task Service"

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_telemetry_service.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_telemetry_service.py
@@ -8,7 +8,11 @@ LICENSE file in the root directory of this source tree.
 :Group Name:	health_check
 :Score Weight:	10
 
-:Description:	This test attempts to get telemetry service
+:Description:	This test verifies the availability and correctness of the Redfish Telemetry Service.
+                The test attempts to retrieve telemetry data from the service and checks for errors.
+
+                PASS Criteria: The test passes if the telemetry data is successfully retrieved and contains no errors.
+                FAIL Criteria: The test fails if the telemetry data cannot be retrieved or contains errors.
 
 :Usage 1:		python ctam.py -w ..\workspace -t H7
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Redfish Telemetry Service"

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_update_service.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_update_service.py
@@ -8,7 +8,11 @@ LICENSE file in the root directory of this source tree.
 :Group Name:	health_check
 :Score Weight:	10
 
-:Description:	This test attempts to get update service
+:Description:	This test verifies the availability and correctness of the Redfish Update Service.
+                The test attempts to retrieve update service data from the service and checks for errors.
+
+                PASS Criteria: The test passes if the update service data is successfully retrieved and contains no errors.
+                FAIL Criteria: The test fails if the update service data cannot be retrieved or contains errors.
 
 :Usage 1:		python ctam.py -w ..\workspace -t H4
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Redfish Update Service"

--- a/ctam/tests/health_check/long_health_check_group/ctam_test_ac_cycles_in_loop.py
+++ b/ctam/tests/health_check/long_health_check_group/ctam_test_ac_cycles_in_loop.py
@@ -8,8 +8,12 @@ LICENSE file in the root directory of this source tree.
 :Group Name:	health_check
 :Score Weight:	10
 
-:Description:	AC Cycle is essential for activation flow of firmware update and many other flows. 
-                This test would run AC cycles in a loop and test platform stability.This is a prerequisite to many other test cases that need the activation flow.   
+:Description:	AC Cycle is essential for activation flow of firmware update and many other flows.
+                This test runs AC cycles in a loop to test platform stability. This is a prerequisite
+                to many other test cases that need the activation flow.
+
+                PASS Criteria: The test passes if all AC cycles complete successfully without errors.
+                FAIL Criteria: The test fails if any AC cycle encounters an error.
 
 :Usage 1:		python ctam.py -w ..\workspace -t H100
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test AC Cycles In Loop"

--- a/ctam/tests/health_check/long_health_check_group/ctam_test_logservice_dump_clearlog.py
+++ b/ctam/tests/health_check/long_health_check_group/ctam_test_logservice_dump_clearlog.py
@@ -8,8 +8,12 @@ LICENSE file in the root directory of this source tree.
 :Group Name:	health_check
 :Score Weight:	10
 
-:Description:	Basic test case to clear all entries of all instances of LogService Dumps
-				
+:Description:	Basic test case to clear all entries of all instances of LogService Dumps.
+                This test ensures that all log entries are cleared successfully.
+
+                PASS Criteria: The test passes if all log entries are cleared without errors.
+                FAIL Criteria: The test fails if any log entry cannot be cleared or an error occurs.
+
 :Usage 1:		python ctam.py -w ..\workspace -t H96
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test LogService Dump Clear"
 

--- a/ctam/tests/health_check/long_health_check_group/ctam_verify_self_test_report.py
+++ b/ctam/tests/health_check/long_health_check_group/ctam_verify_self_test_report.py
@@ -10,6 +10,11 @@ LICENSE file in the root directory of this source tree.
 :Score Weight:	10
 
 :Description:	This test case verifies if self-test reports any failures.
+                The test triggers a self-test, downloads the report, and checks for any failures.
+
+                PASS Criteria: The test passes if the self-test report is successfully retrieved and contains no failures.
+                FAIL Criteria: The test fails if the self-test report cannot be retrieved or contains failures.
+
 :Usage 1:		python ctam.py -w ..\workspace -T H50
 :Usage 2:		python ctam.py -w ..\workspace -T "CTAM Test Verify Self-Test Report"
 

--- a/ctam/tests/ras/ctam_test_collect_crashdump_manager.py
+++ b/ctam/tests/ras/ctam_test_collect_crashdump_manager.py
@@ -8,7 +8,24 @@ LICENSE file in the root directory of this source tree.
 :Group Name:	ras
 :Score Weight:	10
 
-:Description:	Placeholder only. Post CollectDiagnisticData for '\redfish\v1\Managers\{Manager}\LogService\EventLog with DiagnosticDataType = Manager
+:Description:	
+This test verifies the functionality of collecting crashdump diagnostic data for a specific manager in the system. It performs the following steps:
+
+1. Discover the crashdump capabilities using the Redfish API.
+   Example URI: /redfish/v1/Managers/{ManagerID}/LogServices
+2. Trigger the collection of crashdump data for the manager.
+   Post CollectDiagnisticData for '\redfish\v1\Managers\{Manager}\LogService\EventLog with DiagnosticDataType = Manager
+   Example URI: /redfish/v1/Managers/{ManagerID}/LogServices/{LogServiceID}/Actions/LogService.CollectDiagnosticData
+3. Download the crashdump attachment.
+4. Check if the crashdump attachment is successfully downloaded.
+5. If the crashdump attachment is not successfully downloaded, log the failure and mark the test as failed.
+6. If the crashdump attachment is successfully downloaded, mark the test as passed.
+
+PASS Criteria:
+- The crashdump attachment is successfully downloaded.
+
+FAIL Criteria:
+- The crashdump attachment is not successfully downloaded
 
 :Usage 1:		python ctam.py -w ..\workspace -t R2
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Collect Crashdump Manager"

--- a/ctam/tests/ras/ctam_test_collect_crashdump_oem_selftest.py
+++ b/ctam/tests/ras/ctam_test_collect_crashdump_oem_selftest.py
@@ -8,7 +8,25 @@ LICENSE file in the root directory of this source tree.
 :Group Name:	ras
 :Score Weight:	10
 
-:Description:	Placeholder only. Post CollectDiagnisticData for '\redfish\v1\Systems\{BaseboardId}\LogService\EventLog with DiagnosticDataType = OEMSelfTest
+:Description:	 
+This test verifies the Redfish Event Service's capability to collect diagnostic data, 
+manage subscriptions, and validate the availability of diagnostic data types. 
+It also ensures proper error handling and subscription creation when required.
+    
+    Post CollectDiagnisticData for '\redfish\v1\Systems\{BaseboardId}\LogService\EventLog with DiagnosticDataType = OEMSelfTest
+   - The test retrieves `AllowableValues` for `DiagnosticDataType` and `OEMDiagnosticDataType` from:  
+     `https://<BaseURI>/redfish/v1/Systems/{BaseboardId}/LogService/EventLog/Actions/CollectDiagnosticData`.  
+   - Ensures these values are non-empty and valid.
+
+**PASS Criteria:**  
+- `DiagnosticDataType` and `OEMDiagnosticDataType` have valid, non-empty allowable values.  
+- Event Service and subscriptions respond successfully.  
+- New subscriptions are created and retrieved without errors when needed.
+
+**FAIL Criteria:**  
+- Missing or empty `DiagnosticDataType` or `OEMDiagnosticDataType`.  
+- Failure to fetch or validate the Event Service and subscriptions.  
+- Errors during Redfish command execution or invalid response data.
 
 :Usage 1:		python ctam.py -w ..\workspace -t R3
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Collect Crashdump OEM Self Test"

--- a/ctam/tests/ras/ctam_test_discover_crashdump.py
+++ b/ctam/tests/ras/ctam_test_discover_crashdump.py
@@ -8,11 +8,17 @@ LICENSE file in the root directory of this source tree.
 :Group Name:	ras
 :Score Weight:	10
 
-:Description:	Ensure that we have at least one LogServiceids each under Systems and Managers. 
-                Next it checks to see if at least one of them have LogService.CollectDiagnosticData 
-                Return list of uris with LogService.CollectDiagnosticData. For eg. this is a pass. 
+:Description:	This test case ensures that there is at least one LogService ID under both Systems and Managers. It then checks
+                if at least one of them has the LogService.CollectDiagnosticData action available. The test returns a list of URIs
+                with LogService.CollectDiagnosticData.
                 /redfish/v1/Managers/{ManagerId}/LogServices/{LogServiceId}/Actions/CollectDiagnosticData 
                 /redfish/v1/Systems/{ComputerSystemId}/LogServices/{LogServiceId}/Actions/CollectDiagnosticData
+
+                PASS Criteria:
+                - At least one LogService ID under Systems or Managers has the LogService.CollectDiagnosticData action available.
+                
+                FAIL Criteria:
+                - No LogService ID under Systems or Managers has the LogService.CollectDiagnosticData action available.
 
 :Usage 1:		python ctam.py -w ..\workspace -t R1
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Discover Crashdump"

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_redfish_interop_validator.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_redfish_interop_validator.py
@@ -8,7 +8,14 @@ LICENSE file in the root directory of this source tree.
 :Group Name:	Telemetry
 :Score Weight:	10
 
-:Description:	This test case will clone the RIV in temp folder and take json profiles as input.
+:Description:	This test case will clone the Redfish Interop Validator (RIV) in a temporary folder and take JSON profiles as input.
+				It will then run the RIV using these profiles to validate the Redfish service.
+
+				PASS Criteria:
+				- The Redfish Interop Validator runs successfully and validates the Redfish service without errors.
+				
+				FAIL Criteria:
+				- The Redfish Interop Validator encounters errors during validation.
 
 :Usage 1:		python ctam.py -w ..\workspace -t T97
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Redfish Interop Validator"

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_redfish_service_validator.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_redfish_service_validator.py
@@ -8,7 +8,15 @@ LICENSE file in the root directory of this source tree.
 :Group Name:	Telemetry
 :Score Weight:	10
 
-:Description:	It will validate all of the available URIs.
+:Description:	This testcase will clone the RedfishServiceValidator repository and It will validate all of the available URIs under redfish.
+
+                :PASS Criteria: 
+                The test will pass if the Redfish Service Validator command runs successfully and validates
+                the Redfish service without errors.
+
+                :FAIL Criteria: 
+                The test will fail if there is an error in cloning the repository, running the Redfish Service
+                Validator command, or if the validation finds issues with the Redfish service on the DUT.
 
 :Usage 1:		python ctam.py -w ..\workspace -t T0
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Service Validator"

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_mr_list_read.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_mr_list_read.py
@@ -1,14 +1,22 @@
 """
 Copyright (c) Microsoft Corporation
-This source code is licensed under the MIT license found in the 
-LICENSE file in the root directory of this source tree.
+This source code is licensed under the 
+MIT license found in the LICENSE file in the root directory of this source tree.
 
 :Test Name:		CTAM Test Telemetry MR List Read
 :Test ID:		T2
-:Group Name:	telemetry
+:Group Name:	Telemetry
 :Score Weight:	10
 
-:Description:	Basic telemetry test case to discover & print the list of all MRDs
+:Description:	This test case discovers and prints the list of all Metric Report Definitions (MRDs)
+                available on the Device Under Test (DUT). It ensures that the telemetry interface
+                can retrieve the list of MRDs correctly.
+
+:PASS Criteria: The test will pass if the telemetry interface successfully retrieves and prints
+                the list of all MRDs.
+
+:FAIL Criteria: The test will fail if the telemetry interface returns an empty list or encounters
+                any errors while retrieving the MRDs.
 
 :Usage 1:		python ctam.py -w ..\workspace -t T2
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Telemetry MR List Read"

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_mr_read.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_mr_read.py
@@ -5,10 +5,19 @@ LICENSE file in the root directory of this source tree.
 
 :Test Name:		CTAM Test Telemetry MR Read
 :Test ID:		T4
-:Group Name:	telemetry
+:Group Name:	Telemetry
 :Score Weight:	10
 
-:Description:	Basic test case to discover list of all metric reports and  
+:Description:	This test case discovers the list of all metric reports available on the Device Under Test (DUT)
+                and prints their details. It ensures that the telemetry interface can retrieve and display the
+                metric reports correctly.
+
+:PASS Criteria: The test will pass if the telemetry interface successfully retrieves and prints the details
+                of all metric reports.
+
+:FAIL Criteria: The test will fail if the telemetry interface returns an empty list or encounters any errors
+                while retrieving the metric reports.
+
 :Usage 1:		python ctam.py -w ..\workspace -t T4
 :Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Telemetry MR Read"
 

--- a/docker.md
+++ b/docker.md
@@ -1,0 +1,14 @@
+# Docker Set-up
+Packaging for CTAM requires the following things:
+
+- Docker
+- A docker compatible container run time
+- Docker's cross platform build plugin: buildx
+
+## Ubuntu Set-up
+Requires Ubuntu 20.04 or newer.
+
+- Install per dockers official documentation: https://docs.docker.com/engine/install/ubuntu/
+- Make sure to follow the instructions to allow non-root usage: https://docs.docker.com/engine/install/linux-postinstall/
+- Run 'docker buildx ls' and confirm both the linux/amd64 and linux/arm64 targets are available
+    - if not, install qemu: 'sudo apt-get install -y qemu qemu-user-static'

--- a/json_spec/input/dut_info.json
+++ b/json_spec/input/dut_info.json
@@ -9,6 +9,11 @@
 			"type": "string",
 			"value": ""
 		},
+		"ConnectionPort": {
+			"description": "IP Address of Service Entry point to be used",
+			"type": "string",
+			"value": ""
+		},
 		"SSHTunnel": {
 			"description": "Indicates if the user wants to communicate through SSH tunnel",
 			"type": "bool",

--- a/json_spec/input/redfish_uri_config.json
+++ b/json_spec/input/redfish_uri_config.json
@@ -4,13 +4,14 @@
 		"BaseURI":"/{GPUMC}/redfish/v1/",
 		"GPUCheckURI":"/Managers/{ManagerID}",
 		"BaseboardIDs":"['BaseboardIDs']",
-		"MultiPartPushUriSupport":false,
 		"TaskServiceURI": "/TaskService/Tasks/"
 	},
 	"GPU_FWUpdate":{
 		"MultiPartFormData":true,
 		"HttpPushUriTargets":"HttpPushUriTargets",
 		"specific_targets":"[]",
+        "exclude_targets_list": [],
+		"MultiPartPushUriSupport":false,
 		"IsMultiPart":false,
 		"UpdateURI":"/UpdateService"
 	},


### PR DESCRIPTION
Add consolidate report feature for Happy path.
For Negative test scenarios which may contain repeated test cases (TestIDs), apply following considerations
- Longest execution time of the repeated test cases is considered for all 
- Failure of any one instance of the repeated test cases is considered as failed
