### PR TITLE
CTAM 1.1.2 : Release

### DIFF
--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_nocheck.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_nocheck.py
@@ -1,0 +1,139 @@
+r"""
+Copyright (c) AMD
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+
+:Test Name:		CTAM Test Full Device Update No Check
+:Test ID:		F5
+:Group Name:	fw_update
+:Score Weight:	50
+:Description:	This test case verifies that the firware stagging is successful followed by activate.
+                The test can fail with stage failure. No precheck and postcheck is performed in this test case.
+
+:PASS Criteria: The test passes if the staging is successful.
+
+:FAIL Criteria: The test fails if staging is unsuccessful.
+
+:Usage 1:		python ctam.py -w ..\workspace -t F5
+:Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Full Device Update No Check"
+
+:Dependencies:
+
+    .. code-block:: text 
+
+        <redfish_uri_config.json>         : Required - <UpdateURI>, <TaskServiceURI>, <GPUCheckURI>, <MultiPartPushUriSupport>
+                                           Optional - <exclude_targets_list>, <HttpPushUriTargets>, <IsMultiPart>, <MultiPartFormData>
+        <dut_info.json>                   : Required - <FwActivationTimeMax>, <FwStagingTimeMax>, <PowerOffWaitTime>, <PowerOnWaitTime>, <IdleWaitTimeAfterFirmwareUpdate>, <PowerOffCommand>, <PowerOnCommand>
+                                           Optional - <SingleShotPowerCycle>, <SingleShotPowerCycleCommand>
+
+        <package_info.json>               : Required - <Path>, <Package>, <JSON>
+                                           Optional - <HasSignature>, <SignatureStructBytes>
+                            
+        <redfish_response_messages.json>  : Required - <UpdateProgress_Message>
+                                           Optional -  <LargeFWImageUpdate>
+"""
+
+from typing import Optional, List
+from tests.test_case import TestCase
+from ocptv.output import (
+    DiagnosisType,
+    LogSeverity,
+    SoftwareType,
+    TestResult,
+    TestStatus,
+)
+from tests.fw_update.fw_update_group_N._fw_update_group_N import (
+    FWUpdateTestGroupN,
+)
+
+
+class CTAMTestFullDeviceUpdateNoCheck(TestCase):
+    """
+    Verify that full device update staging is successful followed by activation, no precheck and postcheck is performed in this test case.
+
+    :param TestCase: super class for all test cases
+    :type TestCase:
+    """
+
+    test_name: str = "CTAM Test Full Device Update No Check"
+    test_id: str = "F5"
+    score_weight: int = 50
+    tags: List[str] = ["L1"]
+    compliance_level: str = "L1"
+
+    def __init__(self, group: FWUpdateTestGroupN):
+        """
+        _summary_
+        """
+        super().__init__()
+        self.group = group
+
+    def setup(self):
+        """
+        set environment state for this test only
+        """
+        # call super first
+        super().setup()
+
+        # add custom setup here
+        step1 = self.test_run().add_step(f"{self.__class__.__name__}  setup()...")
+        with step1.scope():
+            pass
+
+    def run(self) -> TestResult:
+        """
+        actual test verification
+        """
+        result = True
+        failure_reason = ""
+
+        step1= self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
+        with step1.scope():
+            status, status_msg, task_id = self.group.fw_update_ifc.ctam_stage_fw()
+            failure_reason += " " + status_msg
+            if status:
+                step1.add_log(LogSeverity.INFO, f"{self.test_id} : FW Update Staged")
+            else:
+                step1.add_log(
+                    LogSeverity.ERROR, f"{self.test_id} : FW Update Staging failed"
+                )
+                failure_reason += " " + "FW Update Staging failed"
+                result = False
+
+        if result:
+            step2 = self.test_run().add_step(f"{self.__class__.__name__} run(), step2")  # type: ignore
+            with step2.scope():
+                status, status_msg = self.group.fw_update_ifc.ctam_activate_ac()
+                failure_reason += " " + status_msg
+                if status:
+                    step2.add_log(
+                        LogSeverity.INFO, f"{self.test_id} : FW Update Activate"
+                    )
+                else:
+                    step2.add_log(
+                        LogSeverity.ERROR,
+                        f"{self.test_id} : FW Update Activation Failed",
+                    )
+                    failure_reason += " " + "FW Update Activation Failed"
+                    result = False
+
+        # ensure setting of self.result and self.score prior to calling super().run()
+        self.result = TestResult.PASS if result else TestResult.FAIL
+        if self.result == TestResult.PASS:
+            self.score = self.score_weight
+
+        # call super last to log result and score
+        super().run()
+        return self.result, failure_reason
+
+    def teardown(self):
+        """
+        undo environment state change from setup() above, this function is called even if run() fails or raises exception
+        """
+        # add custom teardown here
+        step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
+        with step1.scope():
+            pass
+
+        # call super teardown last
+        super().teardown()

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_nocheck.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_nocheck.py
@@ -7,7 +7,7 @@ LICENSE file in the root directory of this source tree.
 :Test ID:		F5
 :Group Name:	fw_update
 :Score Weight:	50
-:Description:	This test case verifies that the firware stagging is successful followed by activate.
+:Description:	This test case verifies that the firmware staging is successful followed by activate.
                 The test can fail with stage failure. No precheck and postcheck is performed in this test case.
 
 :PASS Criteria: The test passes if the staging is successful.

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_precheck_only.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_precheck_only.py
@@ -1,0 +1,120 @@
+r"""
+Copyright (c) AMD
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+
+:Test Name:		CTAM Test Full Device Update Precheck Only
+:Test ID:		F3
+:Group Name:	fw_update
+:Score Weight:	0
+:Description:	This test case verifies the precheck flow and expects SoftwareInventory to match against
+                the new firware
+
+:PASS Criteria: The test passes if the SoftwareInventory matches against new firware
+
+:FAIL Criteria: The test fails if the SoftwareInventory does not match against the new firmware
+
+:Usage 1:		python ctam.py -w ..\workspace -t F3
+:Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Full Device Update Precheck Only"
+
+:Dependencies:
+
+    .. code-block:: text 
+
+        <redfish_uri_config.json>         : Required - <UpdateURI>, <TaskServiceURI>, <GPUCheckURI>, <MultiPartPushUriSupport>
+                                           Optional - <exclude_targets_list>, <HttpPushUriTargets>, <IsMultiPart>, <MultiPartFormData>
+
+        <package_info.json>               : Required - <Path>, <Package>, <JSON>
+                                           Optional - <HasSignature>, <SignatureStructBytes>
+                            
+        <redfish_response_messages.json>  : Required - <UpdateProgress_Message>
+                                           Optional -  <LargeFWImageUpdate>
+"""
+
+from typing import Optional, List
+from tests.test_case import TestCase
+from ocptv.output import (
+    DiagnosisType,
+    LogSeverity,
+    SoftwareType,
+    TestResult,
+    TestStatus,
+)
+from tests.fw_update.fw_update_group_N._fw_update_group_N import (
+    FWUpdateTestGroupN,
+)
+
+
+class CTAMTestFullDeviceUpdatePrecheckOnly(TestCase):
+    """
+    Verify that full device SoftwareInventory matches against new firmware
+
+    :param TestCase: super class for all test cases
+    :type TestCase:
+    """
+
+    test_name: str = "CTAM Test Full Device Update Precheck Only"
+    test_id: str = "F3"
+    score_weight: int = 0
+    tags: List[str] = ["L3"]
+    compliance_level: str = "L3"
+
+    def __init__(self, group: FWUpdateTestGroupN):
+        """
+        _summary_
+        """
+        super().__init__()
+        self.group = group
+
+    def setup(self):
+        """
+        set environment state for this test only
+        """
+        # call super first
+        super().setup()
+
+        # add custom setup here
+        step1 = self.test_run().add_step(f"{self.__class__.__name__}  setup()...")
+        with step1.scope():
+            pass
+
+    def run(self) -> TestResult:
+        """
+        actual test verification
+        """
+        result = True
+        failure_reason = ""
+
+        step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
+        with step1.scope():
+            status, status_msg = self.group.fw_update_ifc.ctam_fw_update_precheck()
+            failure_reason = status_msg
+            if status:
+                step1.add_log(LogSeverity.INFO, f"{self.test_id} : Software Inventory matches against new firware")
+            else:
+                step1.add_log(
+                    LogSeverity.ERROR, f"{self.test_id} : Software Inventory does not macthes against the new firware"
+                    )
+                failure_reason += " " + "Precheck verification failed"
+                result = False
+
+        # ensure setting of self.result and self.score prior to calling super().run()
+        self.result = TestResult.PASS if result else TestResult.FAIL
+        if self.result == TestResult.PASS:
+            self.score = self.score_weight
+
+        # call super last to log result and score
+        super().run()
+        return self.result, failure_reason
+
+    def teardown(self):
+        """
+        undo environment state change from setup() above, this function is called even if run() fails or raises exception
+        """
+        # add custom teardown here
+        step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
+        with step1.scope():
+            pass
+
+        # call super teardown last
+        super().teardown()

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_precheck_only.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_precheck_only.py
@@ -8,9 +8,9 @@ LICENSE file in the root directory of this source tree.
 :Group Name:	fw_update
 :Score Weight:	0
 :Description:	This test case verifies the precheck flow and expects SoftwareInventory to match against
-                the new firware
+                the new firmware
 
-:PASS Criteria: The test passes if the SoftwareInventory matches against new firware
+:PASS Criteria: The test passes if the SoftwareInventory matches against new firmware
 
 :FAIL Criteria: The test fails if the SoftwareInventory does not match against the new firmware
 

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_precheck_only.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_precheck_only.py
@@ -90,10 +90,10 @@ class CTAMTestFullDeviceUpdatePrecheckOnly(TestCase):
             status, status_msg = self.group.fw_update_ifc.ctam_fw_update_precheck()
             failure_reason = status_msg
             if status:
-                step1.add_log(LogSeverity.INFO, f"{self.test_id} : Software Inventory matches against new firware")
+                step1.add_log(LogSeverity.INFO, f"{self.test_id} : Software Inventory matches against new firmware")
             else:
                 step1.add_log(
-                    LogSeverity.ERROR, f"{self.test_id} : Software Inventory does not macthes against the new firware"
+                    LogSeverity.ERROR, f"{self.test_id} : Software Inventory does not match against the new firmware"
                     )
                 failure_reason += " " + "Precheck verification failed"
                 result = False

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_staging_only.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_staging_only.py
@@ -1,0 +1,120 @@
+r"""
+Copyright (c) AMD
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+
+:Test Name:		CTAM Test Full Device Update Staging Only
+:Test ID:		F2
+:Group Name:	fw_update
+:Score Weight:	20
+:Description:	This test case verifies that the firware stagging is successful. The test can fail with stage failure.
+                No precheck and postcheck is performed in this test case.
+
+:PASS Criteria: The test passes if the staging is successful.
+
+:FAIL Criteria: The test fails if staging is unsuccessful.
+
+:Usage 1:		python ctam.py -w ..\workspace -t F2
+:Usage 2:		python ctam.py -w ..\workspace -t "CTAM Test Full Device Update Staging Only"
+
+:Dependencies:
+
+    .. code-block:: text 
+
+        <redfish_uri_config.json>         : Required - <UpdateURI>, <TaskServiceURI>, <GPUCheckURI>, <MultiPartPushUriSupport>
+                                           Optional - <exclude_targets_list>, <HttpPushUriTargets>, <IsMultiPart>, <MultiPartFormData>
+
+        <package_info.json>               : Required - <Path>, <Package>, <JSON>
+                                           Optional - <HasSignature>, <SignatureStructBytes>
+                            
+        <redfish_response_messages.json>  : Required - <UpdateProgress_Message>
+                                           Optional -  <LargeFWImageUpdate>
+"""
+
+from typing import Optional, List
+from tests.test_case import TestCase
+from ocptv.output import (
+    DiagnosisType,
+    LogSeverity,
+    SoftwareType,
+    TestResult,
+    TestStatus,
+)
+from tests.fw_update.fw_update_group_N._fw_update_group_N import (
+    FWUpdateTestGroupN,
+)
+
+
+class CTAMTestFullDeviceUpdateStagingOnly(TestCase):
+    """
+    Verify that full device update staging only successful, no precheck and postcheck is performed in this test case.
+
+    :param TestCase: super class for all test cases
+    :type TestCase:
+    """
+
+    test_name: str = "CTAM Test Full Device Update Staging Only"
+    test_id: str = "F2"
+    score_weight: int = 20
+    tags: List[str] = ["L2"]
+    compliance_level: str = "L2"
+
+    def __init__(self, group: FWUpdateTestGroupN):
+        """
+        _summary_
+        """
+        super().__init__()
+        self.group = group
+
+    def setup(self):
+        """
+        set environment state for this test only
+        """
+        # call super first
+        super().setup()
+
+        # add custom setup here
+        step1 = self.test_run().add_step(f"{self.__class__.__name__}  setup()...")
+        with step1.scope():
+            pass
+
+    def run(self) -> TestResult:
+        """
+        actual test verification
+        """
+        result = True
+        failure_reason = ""
+
+        step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
+        with step1.scope():
+            status, status_msg, task_id = self.group.fw_update_ifc.ctam_stage_fw()
+            failure_reason += " " + status_msg
+            if status:
+                step1.add_log(LogSeverity.INFO, f"{self.test_id} : FW Update Staged")
+            else:
+                step1.add_log(
+                    LogSeverity.ERROR, f"{self.test_id} : FW Update Staging failed"
+                )
+                failure_reason += " " + "FW Update Staging failed"
+                result = False
+
+        # ensure setting of self.result and self.score prior to calling super().run()
+        self.result = TestResult.PASS if result else TestResult.FAIL
+        if self.result == TestResult.PASS:
+            self.score = self.score_weight
+
+        # call super last to log result and score
+        super().run()
+        return self.result, failure_reason
+
+    def teardown(self):
+        """
+        undo environment state change from setup() above, this function is called even if run() fails or raises exception
+        """
+        # add custom teardown here
+        step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
+        with step1.scope():
+            pass
+
+        # call super teardown last
+        super().teardown()

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_staging_only.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_staging_only.py
@@ -7,7 +7,7 @@ LICENSE file in the root directory of this source tree.
 :Test ID:		F2
 :Group Name:	fw_update
 :Score Weight:	20
-:Description:	This test case verifies that the firware stagging is successful. The test can fail with stage failure.
+:Description:	This test case verifies that the firmware staging is successful. The test can fail with stage failure.
                 No precheck and postcheck is performed in this test case.
 
 :PASS Criteria: The test passes if the staging is successful.

--- a/release-notes.txt
+++ b/release-notes.txt
@@ -1,3 +1,16 @@
+June 27, 2025
+==============
+
+Version: 1.1.2
+  - Added the following micro compliance flows to the firmware update group.
+    - ctam_test_full_device_update_staging_only (F2 testcase)
+      - Update all devices - stage only. No precheck, no postcheck.
+    - ctam_test_full_device_update_precheck_only (F3 testcase)
+      - No stagging needed. Only precheck flow verification - expect SoftwareInventory
+	to match against new firmware
+    - ctam_test_full_device_update_nocheck (F5 testcase)
+      - Update all devices - stage followed by activate. No precheck and no postcheck.
+
 June 09, 2025
 ==============
 

--- a/release-notes.txt
+++ b/release-notes.txt
@@ -6,7 +6,7 @@ Version: 1.1.2
     - ctam_test_full_device_update_staging_only (F2 testcase)
       - Update all devices - stage only. No precheck, no postcheck.
     - ctam_test_full_device_update_precheck_only (F3 testcase)
-      - No stagging needed. Only precheck flow verification - expect SoftwareInventory
+      - No staging needed. Only precheck flow verification - expect SoftwareInventory
 	to match against new firmware
     - ctam_test_full_device_update_nocheck (F5 testcase)
       - Update all devices - stage followed by activate. No precheck and no postcheck.


### PR DESCRIPTION
    Release Version: 1.1.2
    
    Add Micro Compliance flows to the firmware update group

      - Added the following micro compliance flows to the firmware update group.
        - ctam_test_full_device_update_staging_only (F2 testcase)
          - Update all devices - stage only. No precheck, no postcheck.
        - ctam_test_full_device_update_precheck_only (F3 testcase)
          - No stagging needed. Only precheck flow verification - expect SoftwareInventory
            to match against new firmware
        - ctam_test_full_device_update_nocheck (F5 testcase)
          - Update all devices - stage followed by activate. No precheck and no postcheck.