### PR TITLE
AMD: Update T0 testcase to clone redfishServiceValidator and optimize interface utilities for PLDM package json file

### DIFF
--- a/ctam/interfaces/functional_ifc.py
+++ b/ctam/interfaces/functional_ifc.py
@@ -295,6 +295,44 @@ class FunctionalIfc:
             return ""
         return ""
 
+    def _get_pkg_cfg(self, image_type):
+        """
+        Retrieves the device configuration and package configuration based on the specified image type.
+
+        This is a helper method that maps image types to their corresponding configuration keys
+        and fetches the associated configuration from the device's package_config.
+
+        Args:
+            image_type (str): The type of image to fetch configuration for. Must be one of:
+                - "default": Maps to GPU_FW_IMAGE
+                - "backup": Maps to GPU_FW_IMAGE_BACKUP
+                - "old_version": Maps to GPU_FW_IMAGE_OLD
+                - "corrupt_component": Maps to GPU_FW_IMAGE_CORRUPT_COMPONENT
+
+        Returns:
+            tuple: A tuple containing:
+                - dut: The device under test object
+                - dict: The package configuration dictionary for the specified image type,
+                        or an empty dictionary if the key is not found
+
+        @param image_type The image type identifier string
+        @return tuple Containing the DUT object and its corresponding package configuration
+        """
+        cfg_map = {
+            "default": "GPU_FW_IMAGE",
+            "backup": "GPU_FW_IMAGE_BACKUP",
+            "old_version": "GPU_FW_IMAGE_OLD",
+            "corrupt_component": "GPU_FW_IMAGE_CORRUPT_COMPONENT",
+        }
+
+        key = cfg_map.get(image_type)
+        dut = self.dut()
+
+        if not key:
+            return dut, {}
+
+        return dut, dut.package_config.get(cfg_map[image_type], {})
+
     def get_PLDMPkgJson_file(self, image_type="default"):
         """
         :Description:           Get PLDM package file
@@ -304,46 +342,29 @@ class FunctionalIfc:
         :returns:	            File path
         :rtype:                 string
         """
-        # if not self.dut().package_config:
-        #     raise Exception("Please provide data in package config file to run this test case...")
         pldm_json_file = ""
-        if image_type == "default":
-            pldm_json_file = os.path.join(
-                self.dut().cwd,
-                self.dut().package_config.get("GPU_FW_IMAGE", {}).get("Path", ""),
-                self.dut().package_config.get("GPU_FW_IMAGE", {}).get("JSON", ""),
-            )
+        dut, cfg = self._get_pkg_cfg(image_type)
+        # Special handling for corrupt_component
+        if image_type == "corrupt_component":
+            corrupt_cfg = dut.package_config.get("GPU_FW_IMAGE_CORRUPT_COMPONENT", {})
 
-        elif image_type == "backup":
-            pldm_json_file = os.path.join(
-                self.dut().cwd,
-                self.dut()
-                .package_config.get("GPU_FW_IMAGE_BACKUP", {})
-                .get("Path", ""),
-                self.dut()
-                .package_config.get("GPU_FW_IMAGE_BACKUP", {})
-                .get("JSON", ""),
-            )
-        elif image_type == "old_version":
-            pldm_json_file = os.path.join(
-                self.dut().cwd,
-                self.dut().package_config.get("GPU_FW_IMAGE_OLD", {}).get("Path", ""),
-                self.dut().package_config.get("GPU_FW_IMAGE_OLD", {}).get("JSON", ""),
-            )
-        elif image_type == "corrupt_component":
-            if self.dut().package_config.get("GPU_FW_IMAGE_CORRUPT_COMPONENT", {}).get("JSON", "") != "":
-                pldm_json_file = os.path.join(
-                    self.dut().cwd,
-                    self.dut().package_config.get("GPU_FW_IMAGE_CORRUPT_COMPONENT", {}).get("Path", ""),
-                    self.dut().package_config.get("GPU_FW_IMAGE_CORRUPT_COMPONENT", {}).get("JSON", ""),
-                )
+            # If JSON exists use it
+            if corrupt_cfg.get("JSON"):
+                pldm_json_file = os.path.join(dut.cwd,
+                                            corrupt_cfg.get("Path", ""),
+                                            corrupt_cfg.get("JSON", ""),)
             else:
-                pldm_json_file = os.path.join(
-                    self.dut().cwd,
-                    self.dut().package_config.get("GPU_FW_IMAGE", {}).get("Path", ""),
-                    'corrupted-pkg.fwpkg.json',
-                )
-        return pldm_json_file
+                # Else fallback to default path + corrupted filename
+                fallback_cfg = dut.package_config.get("GPU_FW_IMAGE", {})
+                pldm_json_file = os.path.join(dut.cwd,
+                                            fallback_cfg.get("Path", ""),
+                                            "corrupted-pkg.fwpkg.json",)
+        else:
+            # Normal cases
+            if cfg:
+                pldm_json_file = os.path.join(dut.cwd, cfg.get("Path", ""), cfg.get("JSON", ""),)
+
+        return  pldm_json_file
 
     def get_fwpkg_path(self, image_type="default"):
         """
@@ -351,16 +372,13 @@ class FunctionalIfc:
         Used when JSON is not provided and header is extracted from bundle.
         """
         pkg_path = ""
-        if image_type == "default":
-            cfg = self.dut().package_config.get("GPU_FW_IMAGE", {})
-            pkg_path = os.path.join(self.dut().cwd, cfg.get("Path", ""), cfg.get("Package", ""))
-        elif image_type == "backup":
-            cfg = self.dut().package_config.get("GPU_FW_IMAGE_BACKUP", {})
-            pkg_path = os.path.join(self.dut().cwd, cfg.get("Path", ""), cfg.get("Package", ""))
-        elif image_type == "old_version":
-            cfg = self.dut().package_config.get("GPU_FW_IMAGE_OLD", {})
-            pkg_path = os.path.join(self.dut().cwd, cfg.get("Path", ""), cfg.get("Package", ""))
-        return pkg_path
+
+        dut, cfg = self._get_pkg_cfg(image_type)
+        package = cfg.get("Package")
+        if not package:
+            return ""
+
+        return os.path.join(dut.cwd, cfg.get("Path", ""), package)
 
     def ctam_getfi(self, expanded=0):
         """

--- a/ctam/interfaces/functional_ifc.py
+++ b/ctam/interfaces/functional_ifc.py
@@ -307,7 +307,6 @@ class FunctionalIfc:
                 - "default": Maps to GPU_FW_IMAGE
                 - "backup": Maps to GPU_FW_IMAGE_BACKUP
                 - "old_version": Maps to GPU_FW_IMAGE_OLD
-                - "corrupt_component": Maps to GPU_FW_IMAGE_CORRUPT_COMPONENT
 
         Returns:
             tuple: A tuple containing:
@@ -322,7 +321,6 @@ class FunctionalIfc:
             "default": "GPU_FW_IMAGE",
             "backup": "GPU_FW_IMAGE_BACKUP",
             "old_version": "GPU_FW_IMAGE_OLD",
-            "corrupt_component": "GPU_FW_IMAGE_CORRUPT_COMPONENT",
         }
 
         key = cfg_map.get(image_type)
@@ -344,25 +342,10 @@ class FunctionalIfc:
         """
         pldm_json_file = ""
         dut, cfg = self._get_pkg_cfg(image_type)
-        # Special handling for corrupt_component
-        if image_type == "corrupt_component":
-            corrupt_cfg = dut.package_config.get("GPU_FW_IMAGE_CORRUPT_COMPONENT", {})
 
-            # If JSON exists use it
-            if corrupt_cfg.get("JSON"):
-                pldm_json_file = os.path.join(dut.cwd,
-                                            corrupt_cfg.get("Path", ""),
-                                            corrupt_cfg.get("JSON", ""),)
-            else:
-                # Else fallback to default path + corrupted filename
-                fallback_cfg = dut.package_config.get("GPU_FW_IMAGE", {})
-                pldm_json_file = os.path.join(dut.cwd,
-                                            fallback_cfg.get("Path", ""),
-                                            "corrupted-pkg.fwpkg.json",)
-        else:
-            # Normal cases
-            if cfg:
-                pldm_json_file = os.path.join(dut.cwd, cfg.get("Path", ""), cfg.get("JSON", ""),)
+        # Normal cases
+        if cfg:
+            pldm_json_file = os.path.join(dut.cwd, cfg.get("Path", ""), cfg.get("JSON", ""),)
 
         return  pldm_json_file
 

--- a/ctam/interfaces/fw_update_ifc.py
+++ b/ctam/interfaces/fw_update_ifc.py
@@ -687,33 +687,52 @@ class FWUpdateIfc(FunctionalIfc, metaclass=Meta):
         """
         ComponentIdsAndVersions = {}
         PLDMPkgJson = {}
+
+        dut = self.dut()
+        test_run = self.test_run()
         PLDMPkgJson_file = self.get_PLDMPkgJson_file(image_type=image_type)
 
         # N/N-1: if JSON missing, extract header from bundle and save to run output dir
-        if image_type in ("default", "backup", "old_version") and (not PLDMPkgJson_file or not os.path.isfile(PLDMPkgJson_file)):
+        if not PLDMPkgJson_file or not os.path.isfile(PLDMPkgJson_file):
             fwpkg_path = self.get_fwpkg_path(image_type=image_type)
+
             if fwpkg_path and os.path.isfile(fwpkg_path):
                 try:
                     pldm_parser = PLDMUnpack(fwpkg_path)
+
                     if pldm_parser.parse_pldm_package():
                         pldm_parser.get_full_metadata_json()
                         basename = os.path.basename(fwpkg_path)
-                        header_path = os.path.join(self.dut().output_dir, "{}_header.json".format(basename))
+                        header_path = os.path.join(dut.output_dir,
+                                                    f"{basename}_header.json")
+
                         with open(header_path, "w") as f:
                             json.dump(pldm_parser.full_header, f, indent=4, sort_keys=False)
-                        self.test_run().add_log(LogSeverity.INFO, "Extracted PLDM header from bundle to {}".format(header_path))
+
+                        test_run.add_log(LogSeverity.INFO,
+                                        f"Extracted PLDM header from bundle to {header_path}")
                         PLDMPkgJson_file = header_path
                     else:
-                        self.test_run().add_log(LogSeverity.WARNING, "Failed to parse PLDM package for header: {}".format(fwpkg_path))
+                        test_run.add_log(LogSeverity.WARNING,
+                                        f"Failed to parse PLDM package for header: {fwpkg_path}")
                 except (IOError, OSError) as e:
-                    self.test_run().add_log(LogSeverity.WARNING, "Header extraction failed ({}): {}".format(fwpkg_path, e))
+                    test_run.add_log(LogSeverity.WARNING,
+                                    f"Header extraction failed ({fwpkg_path}): {e}")
             else:
-                self.test_run().add_log(LogSeverity.DEBUG, "Fwpkg not found for image_type={}, skipping header extraction".format(image_type))
+                test_run.add_log(LogSeverity.DEBUG,
+                                f"Fwpkg not found for image_type={image_type}, skipping header extraction")
 
+        # Load JSON if available
         if PLDMPkgJson_file and os.path.isfile(PLDMPkgJson_file):
             with open(PLDMPkgJson_file, "r") as f:
                 PLDMPkgJson = json.load(f)
 
-        jsonmultivaluehunt(PLDMPkgJson, "ComponentIdentifier", "ComponentVersionString", ComponentIdsAndVersions)
-        ComponentIdsAndVersions = {str(hex(int(key, 16))): value for key, value in ComponentIdsAndVersions.items()}
+        jsonmultivaluehunt(PLDMPkgJson, "ComponentIdentifier",
+                            "ComponentVersionString", ComponentIdsAndVersions)
+
+        ComponentIdsAndVersions = {
+            str(hex(int(key, 16))): value
+            for key, value in ComponentIdsAndVersions.items()
+        }
+
         return ComponentIdsAndVersions

--- a/ctam/interfaces/telemetry_ifc.py
+++ b/ctam/interfaces/telemetry_ifc.py
@@ -103,7 +103,30 @@ class TelemetryIfc(FunctionalIfc, metaclass=Meta):
             print(t)
         self.write_test_info("{}".format(mr_json))
         return mr_json
-    
+
+    def get_service_validator_info(self):
+        """
+        Retrieve service validator information from the test runner configuration file.
+
+        This method attempts to read a 'test_runner.json' file located in the DUT's
+        workspace directory and extracts the 'service_validator' section from it.
+
+        Returns:
+            dict: A dictionary containing service validator configuration data.
+                  Returns an empty dictionary if:
+                  - The test_runner.json file does not exist
+                  - The file cannot be read (OSError)
+                  - The file contains invalid JSON (json.JSONDecodeError)
+        """
+        path = os.path.join(self.dut().workspace_dir, "test_runner.json")
+        if not os.path.isfile(path):
+            return {}
+
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                return json.load(f).get("service_validator", {})
+        except (json.JSONDecodeError, OSError):
+            return {}
     
 
     

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_redfish_service_validator.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_redfish_service_validator.py
@@ -29,6 +29,7 @@ LICENSE file in the root directory of this source tree.
 from typing import Optional, List, Union
 from tests.test_case import TestCase
 import os
+import json
 from ocptv.output import (
     DiagnosisType,
     LogSeverity,
@@ -80,14 +81,23 @@ class CTAMTestServiceValidator(TestCase):
         """
         failure_reason = ""
         result = True
+
+        service_validator_info = (
+            self.group.telemetry_ifc.get_service_validator_info()
+            if self.group and self.group.telemetry_ifc
+            else {}
+        )
+        branch_name = service_validator_info.get("branch_name", None)
+        auth_type = service_validator_info.get("auth_type", "Basic")
+
         git = GitUtils()
         step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
         repo_path = "RedfishServiceValidator"
-        
+
         with step1.scope():
             step1.add_log(LogSeverity.INFO, f"Cloning repo for Redfish Service Validator.")
             result = git.clone_repo(repo_url="https://github.com/DMTF/Redfish-Service-Validator.git",
-                                  repo_path="RedfishServiceValidator", branch_name="2.5.1")
+                                  repo_path="RedfishServiceValidator", branch_name=branch_name)
             if not result:
                 step1.add_log(LogSeverity.ERROR, f"Cloning repo for Redfish Service Validator failed.")
                 failure_reason += "Cloning repo failed. "
@@ -106,13 +116,14 @@ class CTAMTestServiceValidator(TestCase):
                 step2.add_log(LogSeverity.INFO, f"Running Redfish Service command.")
                 result, msg = git.validate_redfish_service(file_name=file_name, connection_url=connection_url,
                                                         user_name=self.dut().user_name, user_pass=self.dut().user_pass,
-                                                        auth_type="Basic",
+                                                        auth_type=auth_type,
                                                        log_path=self.dut().logger_path, schema_directory=schema_directory,
                                                        depth="Single",
                                                        service_uri="/redfish/v1")
                 if not result:
-                    step2.add_log(LogSeverity.ERROR, f"Something went wrong while running redfish command. Please see error msg {msg}.")
-                    failure_reason += "Error occurred running Redfish command."
+                    step2.add_log(LogSeverity.ERROR, f"Something went wrong while running redfish command. "
+                                  f"Please see error msg {msg}. Try once with branch name '2.5.1'")
+                    failure_reason += "Error occurred running Redfish command.Try on branch '2.5.1'."
                 else:
                     step2.add_log(LogSeverity.INFO, f"Redfish Service Command ran successfully and validated.")
         

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_redfish_service_validator.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_redfish_service_validator.py
@@ -87,7 +87,7 @@ class CTAMTestServiceValidator(TestCase):
         with step1.scope():
             step1.add_log(LogSeverity.INFO, f"Cloning repo for Redfish Service Validator.")
             result = git.clone_repo(repo_url="https://github.com/DMTF/Redfish-Service-Validator.git",
-                                  repo_path="RedfishServiceValidator")
+                                  repo_path="RedfishServiceValidator", branch_name="2.5.1")
             if not result:
                 step1.add_log(LogSeverity.ERROR, f"Cloning repo for Redfish Service Validator failed.")
                 failure_reason += "Cloning repo failed. "
@@ -105,14 +105,16 @@ class CTAMTestServiceValidator(TestCase):
                 
                 step2.add_log(LogSeverity.INFO, f"Running Redfish Service command.")
                 result, msg = git.validate_redfish_service(file_name=file_name, connection_url=connection_url,
-                                                       user_name=self.dut().user_name, user_pass=self.dut().user_pass,
+                                                        user_name=self.dut().user_name, user_pass=self.dut().user_pass,
+                                                        auth_type="Basic",
                                                        log_path=self.dut().logger_path, schema_directory=schema_directory,
                                                        depth="Single",
                                                        service_uri="/redfish/v1")
                 if not result:
                     step2.add_log(LogSeverity.ERROR, f"Something went wrong while running redfish command. Please see error msg {msg}.")
                     failure_reason += "Error occurred running Redfish command."
-                step2.add_log(LogSeverity.INFO, f"Redfish Service Command ran successfully and validated.")
+                else:
+                    step2.add_log(LogSeverity.INFO, f"Redfish Service Command ran successfully and validated.")
         
         step3 = self.test_run().add_step(f"{self.__class__.__name__} run(), step3")  # type: ignore
         with step3.scope():

--- a/ctam/utils/ctam_utils.py
+++ b/ctam/utils/ctam_utils.py
@@ -101,7 +101,7 @@ class GitUtils():
             return False
 
 
-    def validate_redfish_service(self, file_name, connection_url, user_name, user_pass,
+    def validate_redfish_service(self, file_name, connection_url, user_name, user_pass, auth_type,
                                   log_path, schema_directory, depth, service_uri, *args, **kwargs):
         """_summary_
         This method helps to run the Service validator command,
@@ -112,6 +112,7 @@ class GitUtils():
             connection_url (str): need top give the protocol, ip and port for running the service validator
             user_name (str): Username for the system ip
             user_pass (str): Password for the system ip
+            auth_type (str): The authentication type for running the service validator. It can be Basic or Session based
             log_path (str): The path where we need to store the logs for service validator
             schema_directory (str): The schema file directory.
             depth (str): Need to give depth for running single or across the whole redfish uri's as Tree
@@ -126,27 +127,33 @@ class GitUtils():
         file_name = os.path.join(self.repo_path, file_name)
         schema_directory = os.path.join(self.repo_path, "SchemaFiles")
         service_command = "python {file_name}.py --ip {ip} \
-                -u {user} -p {pwd} --logdir {log_dir} \
+                -u {user} -p {pwd}  --authtype {auth_type} --logdir {log_dir} \
                 --schema_directory {schema_directory} \
                     --payload {depth} {uri}".format(
                         file_name=file_name,
                         ip=connection_url,
                         user=user_name,
                         pwd=user_pass,
+                        auth_type=auth_type,
                         log_dir=log_path,
                         schema_directory=schema_directory,
                         depth=depth,
                         uri=service_uri
                     )
-                    
+
         status, result = self.__class__.ctam_run_dmtf_command(service_command)
         if not status:
             return status, result
+
         result = ''.join(result).strip()
         data = result.replace("\r", "").split("\n")[-1]
-        s_idx = result.index("Elapsed time:")
+        match = re.search(r"Summary\s*[-:]", result)
+        s_idx = match.start() if match else -1
+        if s_idx < 0:
+            return False, result
+
         data = result[s_idx:]
-        res = re.findall(r"(?:Pass|pass):\s+(\d+)", data)
+        res = re.findall(r"pass:\s*(\d+)", data, re.IGNORECASE)
         if res and res[0].isdigit() and int(res[0]) > 0:
             return True, "PASS"
         return False, "FAIL"

--- a/ctam/version.py
+++ b/ctam/version.py
@@ -7,4 +7,4 @@ LICENSE file in the root directory of this source tree.
 
 """
 
-__version__ = "1.1.4"
+__version__ = "1.1.5"

--- a/json_spec/input/spec_1.0/workspace/test_runner.json
+++ b/json_spec/input/spec_1.0/workspace/test_runner.json
@@ -8,6 +8,10 @@
     "debug_mode": true,
     "console_log": true,
     "progress_bar":  false,
+    "service_validator": {
+        "branch_name": "",
+        "auth_type": "Basic"
+    },
     "include_tags": [],
     "exclude_tags": [],
     "test_sequence" : [],

--- a/json_spec/input/spec_1.1/workspace/test_runner.json
+++ b/json_spec/input/spec_1.1/workspace/test_runner.json
@@ -8,6 +8,10 @@
     "debug_mode": true,
     "console_log": true,
     "progress_bar":  false,
+    "service_validator": {
+        "branch_name": "",
+        "auth_type": "Basic"
+    },
     "include_tags": [],
     "exclude_tags": [],
     "test_sequence" : [],


### PR DESCRIPTION
Basic Telemetry Group:Update T0 testcase to clone redfishServiceValidator tag ver:2.5.1
     - Update T0 testcase in Basic Telemetry group to have default
       authentication as Basic and to clone the repo redfishServiceValidator
       with tag ver. 2.5.1

  Interfaces: Refactor PLDM package handling and optimize interface utilities
    - Introduced `_get_pkg_cfg` helper to centralize retrieval of device and
      package configuration based on image type
    - Refactored `get_PLDMPkgJson_file` and `get_fwpkg_path` in functional_ifc.py
      to reduce duplication and improve readability
    - Simplified and optimized `ctam_get_version_from_bundle` in fw_update_ifc.py
      for better fallback handling and cleaner logic
