### PR TITLE
Python 3.12 migration: CTAM stability and cleanup fixes

### DIFF
--- a/ctam/ctam.py
+++ b/ctam/ctam.py
@@ -25,12 +25,12 @@ from version import __version__
 from utils.logger_utils import RedirectOutput
 
 def parse_args():
-    """
+    r"""
     :Description:                       Parse command line arguments
 
     :returns:                           Parsed arguments list
     :rtype:                             List
-    """
+    r"""
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "-t",
@@ -103,7 +103,7 @@ def parse_args():
     return parser.parse_args()
 
 def get_exception_details(exec: Exception = ""):
-    """
+    r"""
     :Description:                           It will trace back the exception object for getting
                                             mode details from the exception
 
@@ -111,7 +111,7 @@ def get_exception_details(exec: Exception = ""):
 
     :returns:                               A dict object for all exception details
     :rtype:                                 Dict
-    """
+    r"""
     exc_type, exc_obj, exc_tb = sys.exc_info()
     temp = exc_tb
 

--- a/ctam/interfaces/comptool_dut.py
+++ b/ctam/interfaces/comptool_dut.py
@@ -1,10 +1,10 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 Copyright (c) NVIDIA CORPORATION
 
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
-"""
+r"""
 
 import os
 import typing as ty
@@ -28,14 +28,14 @@ from utils.ssh_tunnel_utils import SSHTunnelWithLibrary, SSHTunnelWithSshpass
 
 
 class CompToolDut(Dut):
-    """
+    r"""
     This subclass derived from OCP dut allows for faster turnaround to add new functionality.
     Periodically this class can be reviewed to determine what functionality should be moved
     to ocptv Dut
 
     :param Dut: OCP super class
     :type Dut: ocptv.output.Dut
-    """
+    r"""
 
     def __init__(
         self,
@@ -57,7 +57,7 @@ class CompToolDut(Dut):
         name: ty.Optional[str] = None,
         metadata: ty.Optional[Metadata] = None,
     ):
-        """
+        r"""
         Passes same parameter to super class
 
         :param id: identification
@@ -70,7 +70,7 @@ class CompToolDut(Dut):
         :type name: ty.Optional[str], optional
         :param metadata: additional descriptive data, defaults to None
         :type metadata: ty.Optional[Metadata], optional
-        """
+        r"""
         self._debugMode: bool = debugMode
         self._console_log: bool = console_log
         self.__package_config_file = package_config
@@ -126,10 +126,10 @@ class CompToolDut(Dut):
 
 
     def set_up_connection(self):
-        """
+        r"""
         This method sets up connection to the DUT,
         which includes ssh_tunneling, Redfish client setup and login if needed
-        """
+        r"""
         # Set up SSH Tunneling if requested
         if self.ssh_tunnel_required:
             # Set up port forwarding
@@ -198,7 +198,7 @@ class CompToolDut(Dut):
         raise Exception("Connection IP can not be override...")
 
     def run_redfish_command(self, uri, mode="GET", body=None, headers=None, timeout=None):
-        """
+        r"""
         This method is for running redfish commands according to mode and log the output into
         a formatted log file and return the response
         
@@ -213,7 +213,7 @@ class CompToolDut(Dut):
 
         :return: response for requests
         :rtype: response object or None in case of failure
-        """
+        r"""
         try:
             start_time = time.time()
             response = None
@@ -300,7 +300,7 @@ class CompToolDut(Dut):
         
     
     def run_request_command(self, uri, mode="GET", body=None, headers=None, timeout=None, files=None, verify=False):
-        """
+        r"""
         This method is for running redfish commands according to mode and log the output into
         a formatted log file and return the response
         
@@ -315,7 +315,7 @@ class CompToolDut(Dut):
 
         :return: response for requests
         :rtype: response object or None in case of failure
-        """
+        r"""
         try:
             start_time = time.time()
             response = None
@@ -434,7 +434,7 @@ class CompToolDut(Dut):
             
     
     def is_debug_mode(self) -> bool:
-        """
+        r"""
         Typically shouldn't be necessary. Log messages of LogSeverity.DEBUG are filtered.
         So they can exist in final code, and will only be visible if system debug mode is enabled.
         ex self._test_run.add_log(severity=LogSeverity.DEBUG, message=msg)
@@ -442,7 +442,7 @@ class CompToolDut(Dut):
 
         :return: _description_
         :rtype: _type_
-        """
+        r"""
         return self._debugMode
     
     @property
@@ -465,12 +465,12 @@ class CompToolDut(Dut):
         
     
     def GetSystemDetails(self, print_details=0): # FIXME: Use logging method and fix the uri
-        """
+        r"""
         :Description:        Gets the System information from BMC.
 
         :returns:	         System Details & BMC Frimware Version
         :rtype:              None
-        """
+        r"""
         try:
             MyName = __name__ + "." + self.GetSystemDetails.__qualname__
             able_to_get_system_details = True

--- a/ctam/interfaces/functional_ifc.py
+++ b/ctam/interfaces/functional_ifc.py
@@ -1,11 +1,11 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 Copyright (c) NVIDIA CORPORATION
 
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 
-"""
+r"""
 from operator import contains
 import os
 import json
@@ -24,35 +24,35 @@ from interfaces.comptool_dut import CompToolDut
 from utils.fwpkg_utils import FwpkgSignature, PLDMFwpkg, PLDMUnpack
 
 class FunctionalIfc:
-    """
+    r"""
     This super class primarily provides access to the DUT.  It should NOT be used as a collection of miscellaneous
     items.  Create additional focused subclasses from this one.
-    """
+    r"""
 
     _dut: CompToolDut | None = None
     _test_run: Optional[tv.TestRun] = None  # OCP TestRun
 
     @staticmethod
     def SetUpAssociations(testrun: tv.TestRun, dut: CompToolDut):
-        """
+        r"""
         The test framework will instance interfaces first, and then this class static method is used
         to create the class associations.
 
         :param dut: device under test
         :type dut: CompToolDut
-        """
+        r"""
         FunctionalIfc._test_run = testrun
         FunctionalIfc._dut = dut
 
     @staticmethod
     def dut() -> CompToolDut:
-        """
+        r"""
         Robustness check to ensure associations have been setup before used at runtime
 
         :raises NotImplementedError: missed setup
         :return: active dut
         :rtype: CompToolDut
-        """
+        r"""
         if FunctionalIfc._dut:
             return FunctionalIfc._dut
         else:
@@ -60,26 +60,26 @@ class FunctionalIfc:
 
     @staticmethod
     def test_run() -> tv.TestRun:
-        """
+        r"""
         Robustness check to ensure associations have been setup before used at runtime
 
         :raises NotImplementedError: missed setup
         :return: active dut
         :rtype: CompToolDut
-        """
+        r"""
         if FunctionalIfc._test_run:
             return FunctionalIfc._test_run
         else:
             raise NotImplementedError(f"need to call FunctionalIfc.SetUpAssociations")
 
     def __init__(self):
-        """
+        r"""
         Default init for now
-        """
+        r"""
         pass
 
     def ctam_get_component_to_be_corrupted(self, VendorProvidedBundle=True):
-        """
+        r"""
         :Description:                   It will check the package_info.json for CorruptComponentIdentifier.
                                         If both corrupt package and CorruptComponentIdentifier are not provided,
                                         it'll find the first updatable element from firmware inventory.
@@ -89,7 +89,7 @@ class FunctionalIfc:
 
         :returns:		                SoftwareID of the component to be corrupted (in hex format)
         :rtype:                         str. None in case of failure
-        """
+        r"""
         MyName = __name__ + "." + self.ctam_get_component_to_be_corrupted.__qualname__
         vendor_provided_corrupt_pkg = self.dut().package_config.get("GPU_FW_IMAGE_CORRUPT_COMPONENT", {}).get("Package", "")
         if VendorProvidedBundle and vendor_provided_corrupt_pkg == "":
@@ -115,14 +115,14 @@ class FunctionalIfc:
 
 
     def get_JSONFWFilePayload_file(self, image_type="default", corrupted_component_id=None):
-        """
+        r"""
         :Description:           Get Payload file
 
         :param expanded:		image type
 
         :returns:	            File path
         :rtype:                 string
-        """
+        r"""
 
         # FIXME: Refactor.. Lots of repeated code
         # if not self.dut().package_config:
@@ -296,14 +296,14 @@ class FunctionalIfc:
         return ""
 
     def get_PLDMPkgJson_file(self, image_type="default"):
-        """
+        r"""
         :Description:           Get PLDM package file
 
         :param expanded:		image type
 
         :returns:	            File path
         :rtype:                 string
-        """
+        r"""
         # if not self.dut().package_config:
         #     raise Exception("Please provide data in package config file to run this test case...")
         pldm_json_file = ""
@@ -346,10 +346,10 @@ class FunctionalIfc:
         return pldm_json_file
 
     def get_fwpkg_path(self, image_type="default"):
-        """
+        r"""
         Get full path to the fwpkg for the given image type (N/N-1).
         Used when JSON is not provided and header is extracted from bundle.
-        """
+        r"""
         pkg_path = ""
         if image_type == "default":
             cfg = self.dut().package_config.get("GPU_FW_IMAGE", {})
@@ -363,13 +363,13 @@ class FunctionalIfc:
         return pkg_path
 
     def ctam_getfi(self, expanded=0):
-        """
+        r"""
         :Description:               Act Get Firmware Inventory
         :param expanded:		Expand Param
 
         :returns:	                JSON Data after running Redfish command
         :rtype:                     JSON Dict
-        """
+        r"""
         MyName = __name__ + "." + self.ctam_getfi.__qualname__
 
         if expanded == 1:
@@ -393,14 +393,14 @@ class FunctionalIfc:
         return data
 
     def ctam_getsi(self, expanded=0):
-        """
+        r"""
         :Description:       Get Software Inventory
 
         :param expanded:		Expand Param
 
         :returns:	        JSON Data after running Redfish command
         :rtype:             JSON Dict
-        """
+        r"""
         MyName = __name__ + "." + self.ctam_getsi.__qualname__
         if expanded == 1:
             ctam_getsi_uri = self.dut().uri_builder.format_uri(
@@ -422,11 +422,11 @@ class FunctionalIfc:
         return data
 
     def ctam_getts(self):
-        """
+        r"""
         :Description:       Act Get Telemetry Service
         :returns:	        JSON Data after running Redfish command
         :rtype:             JSON Dict
-        """
+        r"""
 
         MyName = __name__ + "." + self.ctam_getts.__qualname__
         ctam_getts_uri = self.dut().uri_builder.format_uri(
@@ -441,11 +441,11 @@ class FunctionalIfc:
         return data
 
     def ctam_getus(self):
-        """
+        r"""
         :Description:       Get Update Service
         :returns:	        JSON Data after running Redfish command
         :rtype:             JSON Dict
-        """
+        r"""
         MyName = __name__ + "." + self.ctam_getus.__qualname__
 
         ctam_getus_uri = self.dut().uri_builder.format_uri(
@@ -464,11 +464,11 @@ class FunctionalIfc:
         return response.dict, ctam_getes_uri
 
     def ctam_getes(self, path=None):
-        """
+        r"""
         :Description:       Get Event Service and child collection items.
         :returns:	        JSON Data after running Redfish command
         :rtype:             JSON Dict
-        """
+        r"""
 
         MyName = __name__ + "." + self.ctam_getes.__qualname__
 
@@ -500,11 +500,11 @@ class FunctionalIfc:
         return data
 
     def ctam_create_es(self, destination, RegistryPrefixes, Context, Protocol):
-        """
+        r"""
         :Description:       Create a subscription
         :returns:	        JSON Data after running Redfish command
         :rtype:             JSON Dict
-        """
+        r"""
         MyName = __name__ + "." + self.ctam_create_es.__qualname__
 
         ctam_uri = self.dut().uri_builder.format_uri(
@@ -520,11 +520,11 @@ class FunctionalIfc:
         return data
 
     def ctam_gettsks(self):
-        """
+        r"""
         :Description:       Get Task Service
         :returns:	        JSON Data after running Redfish command
         :rtype:             JSON Dict
-        """
+        r"""
         MyName = __name__ + "." + self.ctam_getus.__qualname__
 
         ctam_gettsks_uri = self.dut().uri_builder.format_uri(
@@ -538,12 +538,12 @@ class FunctionalIfc:
         return data
 
     def NodeACReset(self):
-        """
+        r"""
         :Description:       It will Reset the node.
 
         :returns:           True if power cycle succeeds, False otherwise
         :rtype:             bool
-        """
+        r"""
         MyName = __name__ + "." + self.NodeACReset.__qualname__
         single_shot_power_cycle = self.dut().dut_config.get("SingleShotPowerCycle", {}).get("value", "")
         single_shot_power_cycle_triggered = False
@@ -607,12 +607,12 @@ class FunctionalIfc:
         return True
 
     def IsGPUReachable(self):
-        """
+        r"""
         :Description:        It will check for GPU is available or not using Redfish command
 
         :returns:	         JSON data after executing redfish command
         :rtype:              JSON Dict
-        """
+        r"""
         MyName = __name__ + "." + self.IsGPUReachable.__qualname__
         ctam_getus_uri = self.dut().uri_builder.format_uri(
             redfish_str="{BaseURI}{GPUCheckURI}", component_type="GPU"
@@ -672,14 +672,14 @@ class FunctionalIfc:
 
     
     def ctam_activate_ac(self, gpu_check=True, fwupd_hyst_wait=True):
-        """
+        r"""
         :Description:					Activate AC
         
         :param check_time:              Check the activation time does not exceed maximum time per spec
 
         :returns:				    	ActivationStatus
         :rtype: 						Bool, string
-        """
+        r"""
         MyName = __name__ + "." + self.ctam_activate_ac.__qualname__
         ActivationStatus = False
         failure_reason = ""
@@ -755,7 +755,7 @@ class FunctionalIfc:
         return ActivationStatus, failure_reason, activation_time
     
     def RedfishTriggerDumpCollection(self, DiagnosticDataType, URI, OEMDiagnosticDataType=None):
-        """
+        r"""
         :Description:                     It will trigger the collection of diagnostic data.
         :param DiagnosticDataType:		  e.g. Manager, OEM etc.
         :param URI:		                  URI for creating URL
@@ -763,7 +763,7 @@ class FunctionalIfc:
 
         :returns:		      JSON data after executing redfish command
         :rtype:               JSON Dict
-        """
+        r"""
         MyName = __name__ + "." + self.RedfishTriggerDumpCollection.__qualname__
         URL = URI + "/LogServices/Dump/Actions/LogService.CollectDiagnosticData"
         msg = "Dump Collection URL = {}".format(URL)
@@ -781,13 +781,13 @@ class FunctionalIfc:
         return JSONData
     
     def RedfishDownloadDump(self, DumpURI):
-        """
+        r"""
         :Description:              It will download the specified dump using redfish command and untar the downloaded dump.
         :param DumpLocation:	   Dump location URI 
 
         :returns:				   DumpPath (Path to downloaded dump)
         :rtype:                    string
-        """
+        r"""
         MyName = __name__ + "." + self.RedfishDownloadDump.__qualname__
         check_response = self.dut().run_redfish_command(uri=DumpURI)
         if check_response.status in range(200, 202):
@@ -827,12 +827,12 @@ class FunctionalIfc:
             return None
 
     def ctam_monitor_task(self, TaskID=""):
-        """
+        r"""
         :Description:       CTAM Monitor a Task
         :param TaskID       Task ID of TaskService/Tasks (for accelerator management) to monitor
         :returns:	        (Task_Completed, JSONData response)
         :rtype:             Tuple
-        """
+        r"""
         Task_Completed = False
         JSONData = {}
         if not TaskID:
@@ -878,7 +878,7 @@ class FunctionalIfc:
 
 
     def ctam_redfish_uri_deep_hunt(self, URI, uri_hunt="", uri_listing=[], uri_analyzed=[],action=0):
-        """
+        r"""
         :Description:			CTAM Redfish URI Deep Hunt - a recursive function to look deep till we find all instances URI
         :param URI:             The top uri under which we are searching for the uri instances (type string)
         :param uri_hunt:        URI we are hunting for (type string).
@@ -888,7 +888,7 @@ class FunctionalIfc:
         :param action           Should be set if we are searching for action uris.
 
         :returns:				None
-        """
+        r"""
         response = self.dut().run_redfish_command("{}{}".format(self.dut().uri_builder.format_uri(redfish_str="{GPUMC}", component_type="GPU"), URI))
         JSONData = response.dict
         if uri_hunt in JSONData:
@@ -918,14 +918,14 @@ class FunctionalIfc:
                         self.ctam_redfish_uri_deep_hunt(URI, uri_hunt, uri_listing, uri_analyzed,action)
 
     def ctam_redfish_uri_hunt(self, URI, uri_hunt="", uri_listing=[]):
-        """
+        r"""
         :Description:			CTAM Redfish URI Hunt - a recursive function to look into Members till we find all instances URI
         :param URI:             The top uri under which we are searching for the uri instances (type string)
         :param uri_hunt:        URI we are hunting for (type string).
         :param uri_listing:     An array that will eventually contain a list of all URIs that house the member to hunt.
 
         :returns:				None
-        """
+        r"""
         response = self.dut().run_redfish_command(uri="{}{}".format(self.dut().uri_builder.format_uri(redfish_str="{GPUMC}", component_type="GPU"), URI))
         JSONData = response.dict
         if uri_hunt in JSONData:
@@ -943,14 +943,14 @@ class FunctionalIfc:
                     i = i + 1
 
     def ctam_redfish_action_hunt(self, ActionJson, target_action_hunt="", uri_listing=[],uri_analyzed=[]):
-        """
+        r"""
         :Description:			CTAM Redfish Action Hunt - a recursive function to look deep till we find all instances that contain a "target" or "actioninfo" whose value has target_action_hunt
         :param ActionJson:              Actions JSON Dict object to work on
         :param target_action_hunt:      URI we are hunting for (type string).
         :param uri_listing:             An array that will eventually contain a list of all URIs that house the member to hunt.
         :param uri_analyzed:            An array that contains the list of uris which are already analyzed.
         :returns:				        None
-        """
+        r"""
 
         if "target" in ActionJson and target_action_hunt in ActionJson["target"] and ActionJson["target"] not in uri_analyzed:
             uri_listing.append(ActionJson["target"])
@@ -966,13 +966,13 @@ class FunctionalIfc:
                     self.ctam_redfish_action_hunt(ActionJson[element], target_action_hunt, uri_listing, uri_analyzed)
 
     def write_test_info(self, message):
-        """
+        r"""
         :Description:           JSON Formatter for CTAM TestInfo File Logging
 
         :param message:		    MEssage to be added
 
         :returns:	            None
-        """
+        r"""
         msg = {
                 "TimeStamp": datetime.now().strftime("%m-%d-%YT%H:%M:%S"),
                 "TestName": self.dut().current_test_name,
@@ -981,7 +981,7 @@ class FunctionalIfc:
         self.dut().test_info_logger.write(json.dumps(msg))
 
     def ctam_verify_expanded(self, JSONData):
-        """
+        r"""
         :Description:					Check if the Redfish API response is expanded correctly (level 1)
 
         :param JSONData:                Redfish response in json/dictionary format
@@ -989,7 +989,7 @@ class FunctionalIfc:
 
         :returns:				    	result (Pass/Fail)
         :rtype: 						Bool
-        """
+        r"""
         result = True
         for element in JSONData:
             # Simple dictionary
@@ -1009,14 +1009,14 @@ class FunctionalIfc:
         return result
 
     def ctam_getepc(self, expanded=1):
-        """
+        r"""
         :Description:       Get Expanded Processor Collection
 
         :param expanded:		Expand Param
 
         :returns:	        JSON Data after running Redfish command
         :rtype:             JSON Dict
-        """
+        r"""
         # [TODO] need to figure out a way to grab all of them.
         MyName = __name__ + "." + self.ctam_getepc.__qualname__
         if expanded == 1:
@@ -1033,11 +1033,11 @@ class FunctionalIfc:
 
 
     def ctam_deles(self):
-        """
+        r"""
         :Description:       Get Event Service and child collection items.
         :returns:	        JSON Data after running Redfish command
         :rtype:             JSON Dict
-        """
+        r"""
         # List all subscritions then grabbing one of them and delete
 
         MyName = __name__ + "." + self.ctam_deles.__qualname__
@@ -1063,7 +1063,7 @@ class FunctionalIfc:
         return result
 
     def ctam_redfish_GET_status_ok(self, uri):
-        """
+        r"""
         :Description:   Check if the Redfish API response status is OK
 
         :param uri:     Redfish uri
@@ -1071,7 +1071,7 @@ class FunctionalIfc:
 
         :returns:       result (Pass/Fail)
         :rtype:         bool
-        """
+        r"""
         result = True
         response = self.dut().run_redfish_command(uri=uri)
         JSONData = response.dict
@@ -1084,10 +1084,10 @@ class FunctionalIfc:
         return result
 
     def ctam_verify_components_health(self):
-        """
+        r"""
         :Description:       Get Firmware Inventory details and check health of all components.
         :returns:	        bool, List of health issue components
-        """
+        r"""
 
         fi_data = self.ctam_getfi(expanded=1)
 
@@ -1099,10 +1099,10 @@ class FunctionalIfc:
         return True, []
     
     def flatten_validator_output(self, testId, testName, logger_path):
-        """
+        r"""
         Moves RedfishInteropValidator_<timestamp> output files to parent folder
         and removes the extra directory to prevent long path issues.
-        """
+        r"""
         subdirs = glob.glob(os.path.join(logger_path, "RedfishInteropValidator_*"))
         dest_path = os.path.join(logger_path, f"{testId}_{testName}")
         os.makedirs(dest_path, exist_ok=True)

--- a/ctam/interfaces/fw_update_ifc.py
+++ b/ctam/interfaces/fw_update_ifc.py
@@ -1,11 +1,11 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 Copyright (c) NVIDIA CORPORATION
 
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 
-"""
+r"""
 import os
 import json
 import time
@@ -22,9 +22,9 @@ except:
 
 
 class FWUpdateIfc(FunctionalIfc, metaclass=Meta):
-    """
+    r"""
     API's related to general health check of the dut
-    """
+    r"""
 
     # _instance: Optional["FWUpdateIfc"] = None
 
@@ -62,7 +62,7 @@ class FWUpdateIfc(FunctionalIfc, metaclass=Meta):
     #     return cls._instance
 
     def PLDMComponentVersions(self, image_type):
-        """
+        r"""
         :Description:       if the FW versions from PLDM bundle file are already populated, just return the existing dictionary.
                             Other
 
@@ -70,19 +70,19 @@ class FWUpdateIfc(FunctionalIfc, metaclass=Meta):
 
         :return:            _PLDMComponentVersions
         :rtype:             dict
-        """
+        r"""
         if not self._PLDMComponentVersions.get(image_type):
             self.test_run().add_log(severity=LogSeverity.INFO, message=f"Populating FW Versions for image_type = {image_type}")
             self._PLDMComponentVersions[image_type] = self.ctam_get_version_from_bundle(image_type)
         return self._PLDMComponentVersions[image_type]
 
     def ctam_get_fw_version(self, PostInstall=0):
-        """
+        r"""
         :Description:               Get Firmware Version
         :param PostInstall:     Get Version after install the Firmware or before installing
 
         :returns:                   None
-        """
+        r"""
 
         MyName = __name__ + "." + self.ctam_get_fw_version.__qualname__
         JSONData = self.ctam_getfi(expanded=1)
@@ -100,13 +100,13 @@ class FWUpdateIfc(FunctionalIfc, metaclass=Meta):
         self.test_run().add_log(LogSeverity.DEBUG, msg)
 
     def ctam_fw_update_precheck(self, image_type="default"):
-        """
+        r"""
         :Description:               Check Firmware before installation
         :param image_type:          Type of the Firmware image
 
         :returns:                   VersionsDifferent
         :rtype:                     Bool
-        """
+        r"""
         MyName = __name__ + "." + self.ctam_fw_update_precheck.__qualname__
         VersionsDifferent = True
         failure_reason = ""
@@ -174,7 +174,7 @@ class FWUpdateIfc(FunctionalIfc, metaclass=Meta):
         corrupted_component_id=None, corrupted_component_list=[],
         check_time=False, specific_targets=[], is_force_update=True
     ):
-        """
+        r"""
         :Description:                           Stage Firmware
         :param partial:                         Partial
         :param image_type:                      Type of Firmware Image
@@ -185,7 +185,7 @@ class FWUpdateIfc(FunctionalIfc, metaclass=Meta):
 
         :returns:                               StageFWOOB_Status, StageFWOOB_Status_message, return_task_id 
         :rtype:                                 Bool, str, str
-        """
+        r"""
         failure_reason = ""
         MyName = __name__ + "." + self.ctam_stage_fw.__qualname__
         StartTime = time.time()
@@ -316,14 +316,14 @@ class FWUpdateIfc(FunctionalIfc, metaclass=Meta):
         return StageFWOOB_Status, stage_msg, FwUpdTaskID, staging_time
 
     def ctam_fw_update_verify(self, image_type="default", corrupted_component_id=None, specific_targets=[], version_check=True):
-        """
+        r"""
         :Description:                   Firmware Update verification
         :param image_type:              Firmware image type
         :param corrupted_component_id:  ComponentIdentifier (in hex format) of the corrupted component image
 
         :returns:                       Update_Verified, string
         :rtype:                         Bool, string
-        """
+        r"""
         MyName = __name__ + "." + self.ctam_fw_update_verify.__qualname__
         Update_Verified = True
         exception = False
@@ -423,11 +423,11 @@ class FWUpdateIfc(FunctionalIfc, metaclass=Meta):
         ]
 
     def get_update_uri(self):
-        """
+        r"""
         :Description:                   Get supported fwupdate uri, multipart push uri over httpush
         :returns:                       whether uri was found, update uri and if it supports multipart push
         :rtype:                         Bool, Str, Bool
-        """
+        r"""
         
         uri = self.dut().uri_builder.format_uri(
             redfish_str="{BaseURI}/UpdateService", component_type="GPU"
@@ -473,14 +473,14 @@ class FWUpdateIfc(FunctionalIfc, metaclass=Meta):
         return PushSuccess
 
     def RedFishFWUpdate(self, BinPath, URI, targets=[], is_multipart=False, is_force_update=True):
-        """
+        r"""
         :Description:         It will update system firmware using redfish command.
         :param BinPath:       Path for the bin
         :param URI:           URI for creating URL
 
         :returns:             JSON data after executing redfish command
         :rtype:               JSON Dict
-        """
+        r"""
         MyName = __name__ + "." + self.RedFishFWUpdate.__qualname__
         JSONData = {}
 
@@ -567,7 +567,7 @@ class FWUpdateIfc(FunctionalIfc, metaclass=Meta):
         return PartialDeviceSelected
 
     def ctam_get_component_to_be_corrupted(self, VendorProvidedBundle=True):
-        """
+        r"""
         :Description:                   It will check the package_info.json for CorruptComponentIdentifier.
                                         If both corrupt package and CorruptComponentIdentifier are not provided,
                                         it'll find the first updatable element from firmware inventory.
@@ -577,7 +577,7 @@ class FWUpdateIfc(FunctionalIfc, metaclass=Meta):
 
         :returns:                       SoftwareID of the component to be corrupted (in hex format)
         :rtype:                         str. None in case of failure
-        """
+        r"""
         MyName = __name__ + "." + self.ctam_get_component_to_be_corrupted.__qualname__
         vendor_provided_corrupt_pkg = self.dut().package_config.get("GPU_FW_IMAGE_CORRUPT_COMPONENT", {}).get("Package", "")
         if VendorProvidedBundle and vendor_provided_corrupt_pkg == "":
@@ -604,7 +604,7 @@ class FWUpdateIfc(FunctionalIfc, metaclass=Meta):
         return corrupt_component_id
 
     def ctam_check_component_fwupd_failure(self, task_message_list, corrupted_component_id):
-        """
+        r"""
         :Description:                       It will check if the task status message list is showing the
                                             corrupted component update failed and all other component
                                             copying (staging) went through.
@@ -614,7 +614,7 @@ class FWUpdateIfc(FunctionalIfc, metaclass=Meta):
 
         :returns:                           NonCorruptCompStaging_Success
         :rtype:                             Bool
-        """
+        r"""
         MyName = __name__ + "." + self.ctam_check_component_fwupd_failure.__qualname__
         NonCorruptCompStaging_Success = True
 
@@ -631,7 +631,7 @@ class FWUpdateIfc(FunctionalIfc, metaclass=Meta):
         return NonCorruptCompStaging_Success
 
     def ctam_get_component_list(self, component_id):
-        """
+        r"""
         :Description:                       It will check FW Inventory and find all the components with
                                             the provided component ID.
 
@@ -639,14 +639,14 @@ class FWUpdateIfc(FunctionalIfc, metaclass=Meta):
 
         :returns:                           List of components with the component ID
         :rtype:                             list
-        """
+        r"""
         JSONData = self.ctam_getfi(expanded=1)
         component_list = []
         jsonhuntall(JSONData, "SoftwareId", component_id, "Id", component_list)
         return component_list
 
     def ctam_compare_active_components_count(self):
-        """
+        r"""
         :Description:                       It will compare FW Inventory from Pre and Post Fw update
                                             to make sure all components have come back online. Raises exception
                                             if pre install and post install details are empty. Make sure to
@@ -654,7 +654,7 @@ class FWUpdateIfc(FunctionalIfc, metaclass=Meta):
 
         :returns:                           AllComponentsActive
         :rtype:                             Bool
-        """
+        r"""
 
         if not self.PreInstallDetails or not self.PostInstallDetails:
             raise RuntimeError(f"Pre and Post install details are missing.\
@@ -675,7 +675,7 @@ class FWUpdateIfc(FunctionalIfc, metaclass=Meta):
         return AllComponentsActive
 
     def ctam_get_version_from_bundle(self, image_type):
-        """
+        r"""
         :Description:           Check PLDM bundle json for FW version by software id.
                                 If JSON not provided for N/N-1, extract from fwpkg and write
                                 <fwpkg_basename>_header.json to run output dir.
@@ -684,7 +684,7 @@ class FWUpdateIfc(FunctionalIfc, metaclass=Meta):
 
         :returns:               ComponentVersions
         :rtype:                 string
-        """
+        r"""
         ComponentIdsAndVersions = {}
         PLDMPkgJson = {}
         PLDMPkgJson_file = self.get_PLDMPkgJson_file(image_type=image_type)

--- a/ctam/interfaces/health_check_ifc.py
+++ b/ctam/interfaces/health_check_ifc.py
@@ -1,11 +1,11 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 Copyright (c) NVIDIA CORPORATION
 
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 
-"""
+r"""
 import time
 import json
 import os
@@ -20,9 +20,9 @@ except:
 
 
 class HealthCheckIfc(FunctionalIfc, metaclass=Meta):
-    """
+    r"""
     API's related to general health check of the dut
-    """
+    r"""
 
     # _instance: Optional["HealthCheckIfc"] = None
 
@@ -49,18 +49,18 @@ class HealthCheckIfc(FunctionalIfc, metaclass=Meta):
 
     @classmethod
     def get_instance(cls, *args, **kwargs):
-        """
+        r"""
         if there is an existing instance, return it, otherwise create the singleton instance and return it
 
         :return: instance
         :rtype: HealthCheckIfc
-        """
+        r"""
         if not isinstance(cls._instance, cls):
             cls._instance = cls(*args, **kwargs)
         return cls._instance
     
     def ctam_get_all_logservice_uris(self, resource_collection_list=["Systems", "Managers", "Chassis"]):
-        """
+        r"""
         :Description:	                    Look for "LogService" URIs under specific resourcse collection.
 
         :param resource_collection_list:    list of resource collectionsto check. Default is ["Systems", "Managers", "Chassis"]
@@ -68,7 +68,7 @@ class HealthCheckIfc(FunctionalIfc, metaclass=Meta):
         
         :return:                            list of LogServices uri
         :rtype:                             list
-        """
+        r"""
         for resource_collection in resource_collection_list:
             # Skip populating the list for this resource if it's present already
             if resource_collection not in self.logservice_uri_dict:
@@ -83,7 +83,7 @@ class HealthCheckIfc(FunctionalIfc, metaclass=Meta):
         return self.logservice_uri_list
     
     def ctam_verify_logservice_presence(self, resource_collection_list=["Systems", "Managers"]):
-        """
+        r"""
         :Description:	                    Verify if "LogService" URIs is present under the specified resourcse collection.
 
         :param resource_collection_list:    list of resource collectionsto check. Default is ["Systems", "Managers", "Chassis"]
@@ -91,7 +91,7 @@ class HealthCheckIfc(FunctionalIfc, metaclass=Meta):
         
         :return:                            result (Pass/Fail)
         :rtype:                             bool
-        """
+        r"""
         result = True
         if self.logservice_uri_dict == {}:
             self.test_run().add_log(LogSeverity.ERROR, f"LogServices URI List is empty. Nothing to verify!")
@@ -124,12 +124,12 @@ class HealthCheckIfc(FunctionalIfc, metaclass=Meta):
         return result
     
     def trigger_self_test_dump_collection(self):
-        """
+        r"""
         :Description:							Trigger Self-test Dump Collection
 
         :returns:				    			SelfTestDump_Status
         :rtype: 								Bool
-        """
+        r"""
         MyName = __name__ + "." + self.trigger_self_test_dump_collection.__qualname__
         StartTime = time.time()
         instances = ast.literal_eval(self.dut().uri_builder.format_uri(redfish_str="{BaseboardIDs}", component_type="GPU"))
@@ -183,12 +183,12 @@ class HealthCheckIfc(FunctionalIfc, metaclass=Meta):
         return SelfTestDump_Status
     
     def download_self_test_dump(self):
-        """
+        r"""
         :Description:							Download Self-test Dump
 
         :returns:				    			SelfTestDump_Status
         :rtype: 								Bool
-        """
+        r"""
         MyName = __name__ + "." + self.download_self_test_dump.__qualname__
         
         if self.selftest_dump_entry_uri:
@@ -206,12 +206,12 @@ class HealthCheckIfc(FunctionalIfc, metaclass=Meta):
         return SelfTestDump_Status
 
     def check_self_test_report(self):
-        """
+        r"""
         :Description:							Check Self-test Report for any Failure
 
         :returns:				    			SelfTestReport_Status
         :rtype: 								Bool
-        """
+        r"""
         MyName = __name__ + "." + self.download_self_test_dump.__qualname__
         SelfTestReport_Status = False
         
@@ -229,7 +229,7 @@ class HealthCheckIfc(FunctionalIfc, metaclass=Meta):
         return SelfTestReport_Status
     
     def ctam_get_all_logdump_uris(self, resource_collection_list=["Systems", "Managers"]):
-        """
+        r"""
         :Description:	                    Look for Dump URIs under all LogServices URIs of specific resourcse collection.
         
         :param resource_collection_list:    list of resource collectionsto check. Default is ["Systems", "Managers", "Chassis"]
@@ -237,7 +237,7 @@ class HealthCheckIfc(FunctionalIfc, metaclass=Meta):
 
         :return:                            list of LogServices Dump uri
         :rtype:                             list
-        """
+        r"""
         self.ctam_get_all_logservice_uris(resource_collection_list)
         for resource in resource_collection_list:
             dumplog_uri_list = []
@@ -249,7 +249,7 @@ class HealthCheckIfc(FunctionalIfc, metaclass=Meta):
         return self.dumplog_uri_list
     
     def ctam_verify_logdump_presence(self, resource_collection_list=["Systems", "Managers"]):
-        """
+        r"""
         :Description:	                    Verify if the Dump URI is present under all LogServices URI of specified resourcse collection.
         
         :param resource_collection_list:    list of resource collectionsto check. Default is ["Systems", "Managers", "Chassis"]
@@ -257,7 +257,7 @@ class HealthCheckIfc(FunctionalIfc, metaclass=Meta):
 
         :return:                            result if the verification passed/failed
         :rtype:                             bool
-        """
+        r"""
         result = True
         if self.dumplog_uri_dict == {}:
             self.test_run().add_log(LogSeverity.ERROR, f"LogServices Dump URI List is empty. Nothing to verify!")

--- a/ctam/interfaces/ras_ifc.py
+++ b/ctam/interfaces/ras_ifc.py
@@ -1,10 +1,10 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 
-"""
+r"""
 
 from typing import Optional, List
 from interfaces.functional_ifc import FunctionalIfc
@@ -24,11 +24,11 @@ class RasIfc(FunctionalIfc, metaclass=Meta):
 
     
     def ctam_discover_crashdump_cap(self):
-        """
+        r"""
         :Description:				Get CollectDiagnosticDataActionInfo 
 
         :returns:				    List of all action uris with LogService.CollectDiagnosticData
-        """
+        r"""
         collectdiagnostic_uri_list = []
         logservice_ras_uri_list = self.ctam_get_collectdiagnostic_logservices_uris()
         for uri in logservice_ras_uri_list:
@@ -37,11 +37,11 @@ class RasIfc(FunctionalIfc, metaclass=Meta):
         return collectdiagnostic_uri_list
     
     def ctam_get_collectdiagnostic_logservices_uris(self):
-        """
+        r"""
         :Description:				Similar to logservice uri list under health check interface, but only for systems and managers. 
 
         :returns:				    List of all URIs with "LogServices" as a property under /redfish/v1/Managers and /redfish/v1/Systems
-        """
+        r"""
         collectdiagnostic_logservices_uri_list=[]
         self.ctam_redfish_uri_deep_hunt("/redfish/v1/Managers", "LogServices", collectdiagnostic_logservices_uri_list, uri_analyzed=[])
         self.ctam_redfish_uri_deep_hunt("/redfish/v1/Systems", "LogServices", collectdiagnostic_logservices_uri_list, uri_analyzed=[])
@@ -58,14 +58,14 @@ class RasIfc(FunctionalIfc, metaclass=Meta):
         return collect_managers_list
     
     def check_location_list(self, JSONData):
-        """_summary_
+        r"""_summary_
 
         Args:
             JSONData (_type_): _description_
 
         Returns:
             _type_: _description_
-        """
+        r"""
         location_list = JSONData.get("Payload", {}).get("HttpHeaders", [])
         if not location_list:
             self.test_run().add_log(LogSeverity.FATAL, "Location list is not found")

--- a/ctam/interfaces/telemetry_ifc.py
+++ b/ctam/interfaces/telemetry_ifc.py
@@ -1,10 +1,10 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 
-"""
+r"""
 
 from typing import Optional, List
 from interfaces.functional_ifc import FunctionalIfc
@@ -50,14 +50,14 @@ class TelemetryIfc(FunctionalIfc, metaclass=Meta):
     #     return cls._instance
     
     def ctam_redfish_hunt(self, URI, member_hunt="", uri_listing=[]):
-        """
+        r"""
         :Description:			CTAM Redfish hunt - a recursive function to look deep til we find the member to hunt
         :param URI:             The uri under which we are searching for the member to hunt (type string)
         :param member_hunt:     Json member we are hunting for (type string).
         :param uri_listing:     An array that will eventually contain a list of all URIs that house the member to hunt.
 
         :returns:				None
-        """
+        r"""
         response = self.dut().run_redfish_command(uri="{}{}".format(self.dut().uri_builder.format_uri(redfish_str="{GPUMC}", component_type="GPU"), URI))
         JSONData = response.dict
         if member_hunt in JSONData:
@@ -72,12 +72,12 @@ class TelemetryIfc(FunctionalIfc, metaclass=Meta):
                     i = i + 1
 
     def ctam_get_all_metric_reports_uri(self):
-        """
+        r"""
         :Description:				Function to build a list of all URIs that house a metric reports (MRs).
                                     Uses a recursive function to dig deep into Metric Report URIs which contain "MetricValues"
 
         :returns:				    Array of all URIs (type string)
-        """
+        r"""
         MyName = __name__ + "." + self.ctam_get_all_metric_reports_uri.__qualname__
         JSONData = self.ctam_getts()
         if "MetricReports" in JSONData:

--- a/ctam/interfaces/uri_builder.py
+++ b/ctam/interfaces/uri_builder.py
@@ -1,40 +1,40 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 
-"""
+r"""
 import json
 from enum import Enum
 
 
 class UriBuilder:
-    """
+    r"""
     Due to varying architectures,  not all redfish paths will be exactly the same in all cases.
     Rather than distribute those variations across the system, this class localizes the changes here.
     See 'format_uri' documentation below for specifics
-    """
+    r"""
 
     def __init__(self, redfish_uri_config):
-        """
+        r"""
         Read in dut json data
 
         :param dut_info: json data from dut_info.json
         :type dut_info: json data
         :raises Exception: on invalid data set
-        """
+        r"""
 
-        """
+        r"""
         Following are the variables for substitution in redfish strings.
         Note at a minimum, if the variable is in the incoming string, it will be replaced with "/"
         Therefore incoming strings must take this into account.
 
-        """
+        r"""
         self.redfish_uri_config = redfish_uri_config
 
     def format_uri(self, redfish_str: str, component_type: str) -> str:
-        """
+        r"""
         This method substitutes uri variables with values configured for the particular system under test.
         The available variables are listed in redfish_uri_variables above.  Note the variable substitutes will
         always have a trailing forward slash '/'.  Therefore, the incoming strings must take this into account.
@@ -48,7 +48,7 @@ class UriBuilder:
         :type redfish_str: str
         :return: formatted string
         :rtype: str
-        """
+        r"""
         try:
             uri = redfish_str.format(**self.redfish_uri_config.get(component_type, {}))
             # print("URL: {}".format(uri))

--- a/ctam/test_hierarchy.py
+++ b/ctam/test_hierarchy.py
@@ -1,10 +1,10 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 
-"""
+r"""
 
 import ast
 import os
@@ -19,25 +19,25 @@ from prettytable import PrettyTable
 
 
 class TestHierarchy:
-    """
+    r"""
     This scans the tests directory structure and creates hierarchal dictionary of test groups
     and their associated test cases
 
-    """
+    r"""
 
     class ClassVisitor(ast.NodeVisitor):
-        """
+        r"""
         ast is a module that does the heavy lifting of scanning python files and arranging file contents
         into an easily parsable structure. This helper class is derived from ast and allows for custom inspection.
 
         :param ast: _description_
         :type ast: _type_
-        """
+        r"""
 
         def __init__(self):
-            """
+            r"""
             Re-init class values after every class visit.  Code below saves this info first
-            """
+            r"""
             self.test_groups = (
                 {}
             )  # dictionary with key is TestGroup, and value is a List of Testcases
@@ -58,7 +58,7 @@ class TestHierarchy:
                 raise ValueError(f"Unsupported node: {ast.dump(node)}")
 
         def visit_ClassDef(self, node):
-            """
+            r"""
             As part of ast, this function is a callback called during the line below:
             visitor.visit(tree)
 
@@ -70,7 +70,7 @@ class TestHierarchy:
 
             :param node: ast node
             :type node: ast node
-            """
+            r"""
             self.class_names.append(node.name)
             for base in node.bases:
                 if isinstance(base, ast.Name):
@@ -117,26 +117,26 @@ class TestHierarchy:
             self.generic_visit(node)
 
     def __init__(self, test_root_dir, ifc_dir):
-        """
+        r"""
         Only need to instantiate object and hierarchy is made available
 
         :param test_root_dir: entry point for all tests in the system
         :type test_root_dir: str
         :param ifc_dir: entry point for interfaces
         :type ifc_dir: str
-        """
+        r"""
         self.test_root_dir = test_root_dir
         self.ifc_dir = ifc_dir
         self.test_groups = self._find_groups_and_cases()
         self.ifc_files = self._find_ifc_files()
 
     def _find_ifc_files(self):
-        """
+        r"""
         _summary_
 
         :return: create a List of all of the interfaces. The List contains enough information to auto instantiate
         :rtype: List
-        """
+        r"""
         ifc_files = {}
 
         for root, dirs, files in os.walk(self.ifc_dir):
@@ -166,12 +166,12 @@ class TestHierarchy:
         return ifc_files
 
     def _find_groups_and_cases(self):
-        """
+        r"""
         Walk directory structure and find TestGroups and TestCases. Then assign the test cases according to the groups it belongs to.
 
         :return: List of TestGroups which contains a list of TestCases for that group
         :rtype: List
-        """
+        r"""
         visitor = self.ClassVisitor()
         test_root_dirs = ""
         if isinstance(self.test_root_dir, str):
@@ -232,9 +232,9 @@ class TestHierarchy:
         return visitor.test_groups
 
     def print_test_groups_all_info(self):
-        """
+        r"""
         Loop through hierarchy and print information
-        """
+        r"""
         for group_name, group_info in self.test_groups.items():
             print(f"Test Group Name: {group_name}")
             print(f'  Module Name: {group_info["module_name"]}')
@@ -249,22 +249,22 @@ class TestHierarchy:
                     print(f"        {attribute}: {value}")
 
     def get_total_group_cases(self, group):
-        """
+        r"""
         searches for group in test_groups and returns the number of test cases in that group
-        """
+        r"""
         for group_name, group_info in self.test_groups.items():
             if group_info["group_attributes"].get("group_id") == group or \
                 group == group_info["group_attributes"].get("group_name"):
                 return len(group_info["test_cases"])
 
     def print_test_groups_test_cases(self, group_name=None):
-        """
+        r"""
         Print test cases associated for a single test group
         If optional parameter is not included, print all groups
 
         :param group_name: Name of group, defaults to None
         :type group_name: str, optional
-        """
+        r"""
         t = PrettyTable(["GroupID", "GroupName", "GroupTag", "TestCaseID", "TestCaseName", "TestCaseTag", "TestCaseWeightScore", "Spec Versions"])
         t.title = "Test Case info table"
 
@@ -311,14 +311,14 @@ class TestHierarchy:
         print(t)
 
     def _find_testcase(self, param):
-        """
+        r"""
         Search all the test groups and see if param matches the testcase_name or test_id
 
         :param param: search item
         :type param: str
         :return: group attributes, test case attributes
         :rtype: group, testcase
-        """
+        r"""
         for group_name, group_info in self.test_groups.items():
             for testcase in group_info["test_cases"]:
                 # Check if the param matches the testcase name or the test_id
@@ -331,14 +331,14 @@ class TestHierarchy:
         return None, None
 
     def _find_group(self, param):
-        """
+        r"""
         Search all the test groups and see if param matches the group_name or group_id
 
         :param param: search item
         :type param: str
         :return: group attributes, 
         :rtype: group
-        """
+        r"""
         for group_name, group_info in self.test_groups.items():
             # print(group_name, group_info)
             # for group in group_info["group_attributes"]:
@@ -378,7 +378,7 @@ class TestHierarchy:
         return compliance_test_count  
     
     def _instantiate_object(self, obj_info, class_name, init_param=None):
-        """
+        r"""
         Used to instantiate a TestGroup or TestCase
 
         :param obj_info: metadata for the object to be instantiated
@@ -389,7 +389,7 @@ class TestHierarchy:
         :type init_param: str, optional
         :return: object instance, object module
         :rtype: object instance, object module
-        """
+        r"""
         module_name = obj_info.get("module_name")
         module_path = obj_info.get("module_path")
 
@@ -420,14 +420,14 @@ class TestHierarchy:
             raise
 
     def instantiate_obj_for_group(self, group_name):
-        """
+        r"""
         When given a TestGroup instantiate it and it's associated TestCases
 
         :param group_name: Name of the TestGroup
         :type group_name: str
         :return: group instance, List of Test Cases
         :rtype: group instance, List of Test Cases
-        """
+        r"""
         group_info = self._find_group(group_name)
         # group_info = self.test_groups.get(group_name)
         if not group_info:
@@ -452,7 +452,7 @@ class TestHierarchy:
         return group_instance, test_case_instances
 
     def instantiate_obj_for_testcase(self, testcase_name):
-        """
+        r"""
         When given a test case, search the hierarchy for the group it is in,
         instantiate the group and the single test case
 
@@ -460,7 +460,7 @@ class TestHierarchy:
         :type testcase_name: str
         :return: group instance, List with one entry of the test case(list is so upper level code works the same)
         :rtype: group instance, List of single testcase instance
-        """
+        r"""
         group_info, testcase_info = self._find_testcase(testcase_name)
         if not group_info or not testcase_info:
             print(f"Test case {testcase_name} not found.")
@@ -481,7 +481,7 @@ class TestHierarchy:
         return group_instance, [test_case_instance]
 
     def _parse_configure_interfaces(self, configure_interfaces_method):
-        """
+        r"""
         Pass in a configure_interfaces method from a TestGroup subclass
         ex: def configure_interfaces(self, hc_ifc: HealthCheckIfc):
 
@@ -492,7 +492,7 @@ class TestHierarchy:
         :type configure_interfaces_method: _type_
         :return: List of interface instances
         :rtype: List
-        """
+        r"""
         instances = []
 
         parameters = (inspect.signature(configure_interfaces_method)).parameters

--- a/ctam/test_runner.py
+++ b/ctam/test_runner.py
@@ -1,11 +1,11 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 Copyright (c) NVIDIA CORPORATION
 
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 
-"""
+r"""
 from pathlib import Path
 import os
 import re
@@ -44,9 +44,9 @@ COUNTER = 0
 
 
 class TestRunner:
-    """
+    r"""
     This class is the main controller for test execution
-    """
+    r"""
 
     def __init__(
         self,
@@ -69,7 +69,7 @@ class TestRunner:
         spec_version=None,
         test_runner_spec_version=None,
     ):
-        """
+        r"""
         Init function that handles test execution variations
 
         :param test_hierarchy: discovered list of test groups and associated test cases
@@ -91,7 +91,7 @@ class TestRunner:
         :param single_group_override: single group to run, defaults to None
         :type single_group_override: str, optional
         :raises Exception: no tests to run
-        """
+        r"""
         self.active_run = None
         self.comp_tool_dut = None
         self.test_hierarchy = test_hierarchy
@@ -232,7 +232,7 @@ class TestRunner:
         runner_exc_tags_set,
         # test_exc_tags,
     ):
-        """
+        r"""
         Helper function that inspects include and exclude tags to determine if group or test should run
             If exclude_tags list is not empty AND test_case_tag in exclude_tag list, 
             then exclude test case
@@ -253,7 +253,7 @@ class TestRunner:
         :type test_exc_tags: List[str]
         :return: true if it should run
         :rtype: bool
-        """
+        r"""
         if runner_exc_tags_set and any(tag in runner_exc_tags_set for tag in tags):
             return False
 
@@ -267,12 +267,12 @@ class TestRunner:
             
 
     def _start(self, testrun_name="initialization"):
-        """
+        r"""
         Helper function called at the start of every OCP test run
 
         :param testrun_name: name for the testrun
         :type testrun_name: str
-        """
+        r"""
         # system is up or not
         # If up then establish the connection and the discovery 
         self.cwd = os.path.dirname(os.path.dirname(__file__))
@@ -356,14 +356,14 @@ class TestRunner:
         # self.active_run.start(dut=tv.Dut(id="dut0"))
 
     def _end(self, run_status, run_result):
-        """
+        r"""
         Helper function called at the end of the OCP Testrun
 
         :param run_status: overall run status
         :type run_status: str
         :param run_result: overall run result
         :type run_result: str
-        """
+        r"""
         self.active_run.end(status=run_status, result=run_result)
         tv.config(writer=StdoutWriter())
 
@@ -377,12 +377,12 @@ class TestRunner:
                 testcase.score_weight = self.weighted_scores[tag]
             
     def run(self):
-        """
+        r"""
         Public API used to kick of the test suite
         
         :return: status_code, exit_string
         :rtype: int, str 
-        """
+        r"""
         try:
             status_code = 0
             self.create_json_configuration()
@@ -413,7 +413,7 @@ class TestRunner:
                         self.total_cases = len(self.test_sequence)
                         progress_thread.start()
 
-                """
+                r"""
                 1.Initialize previous_test_result:
                     The variable previous_test_result is initialized as True, representing the result of the previous test.
                 2.Iterate Over Test Sequence:
@@ -425,7 +425,7 @@ class TestRunner:
                 4.Update Previous Test Result:
                     Assign the result of the current test (group_result.value) to previous_test_result.
 
-                """
+                r"""
                 previous_test_result = True       
                 for index, test in enumerate(self.test_sequence):
                     if test == "PROF":
@@ -552,9 +552,9 @@ class TestRunner:
             return status_code, exit_string
         
     def consolidate_run(self):
-        """
+        r"""
         Consolidates test results from multiple JSON files and generates a final consolidated report.
-        """
+        r"""
         try:
             status_code = 0
             exit_string = "Test consolidation completed successfully"
@@ -612,10 +612,10 @@ class TestRunner:
         return status_code, exit_string
 
     def get_consolidated_test_scores(self,log_paths, consolidated_output_json):
-        """
+        r"""
         Retrieves JSON files matching the TestScore* filename from given folder paths,
         consolidates into a single JSON file.
-        """
+        r"""
         self.test_score_data = []
 
         for folder_path in log_paths:
@@ -677,9 +677,9 @@ class TestRunner:
         print(f"Consolidated JSON saved at: {consolidated_output_json}")
     
     def load_fixed_json(self, file_path):
-        """
+        r"""
         Reads and fixes improperly formatted JSON files before parsing.
-        """
+        r"""
         try:
             with open(file_path, "r", encoding="utf-8") as file:
                 content = file.read().strip()
@@ -706,7 +706,7 @@ class TestRunner:
 
        
     def _run_group_test_cases(self, group_instance, test_case_instances):
-        """
+        r"""
         for now, create a separate test run for each group. In the event of failures
         that will require smaller test runs to debug and evaluate resolutions
 
@@ -716,7 +716,7 @@ class TestRunner:
         :type test_case_instances: List[Testcase]]
         :returns: group_status, group_result
         :rtype:  ocptv.output.TestStatus, ocptv.output.TestResult
-        """
+        r"""
         global COUNTER
         group_status = TestStatus.ERROR
         group_result = TestResult.PASS
@@ -897,9 +897,9 @@ class TestRunner:
     
     
     def filter_and_update_test_results(self, test_instance, execution_time, failure_reason=None):
-        """
+        r"""
         Filter and update the test result cache with the current test instance based on result and execution time.
-        """
+        r"""
         
         test_id = test_instance.test_id
         test_result = TestResult(test_instance.result).name
@@ -935,9 +935,9 @@ class TestRunner:
 
           
     def generate_test_score_summary(self, filtered_data_dict=None, test_score_data=None):
-        """
+        r"""
         Generate a detailed JSON report summarizing test execution metrics, scores, and compliance levels for all test cases.
-        """
+        r"""
 
         try:
             # Generate a timestamped json filename for better tracking
@@ -1023,9 +1023,9 @@ class TestRunner:
     
         
     def domain_data(self, test_instance, t_score, execution_time, test_result, test_report):
-        """
+        r"""
         Update domain-wise test metrics in the test_score_summary.json report based on the current test execution.
-        """
+        r"""
 
         domain_count = self.test_hierarchy.get_domains()
         
@@ -1067,9 +1067,9 @@ class TestRunner:
             print(f"Warning: No matching domain found for test ID {test_instance.test_id}")
                         
     def compliance_level_weighted_data(self, test_instance, t_score, execution_time, test_result, test_report):
-        """
+        r"""
         Update compliance-level metrics in the test_score_summary.json based on current test execution.
-        """
+        r"""
 
         compliance_level = test_instance.compliance_level if test_instance.compliance_level in self.weighted_scores else "L3"
         available_testcases = self.test_hierarchy.get_compliance_test_cases()
@@ -1100,10 +1100,10 @@ class TestRunner:
         compliance["total_execution_time"] += execution_time
         
     def compliance_level_normalized_data(self, test_instance, t_score, execution_time, test_result, test_report):
-        """
+        r"""
         Update normalized compliance-level metrics and overall compliance in the test_score_summary.json 
         based on current test execution.
-        """
+        r"""
         compliance_level = test_instance.compliance_level if test_instance.compliance_level in self.weighted_scores else "L3"
         domain_count = self.test_hierarchy.get_domains()
         available_testcases = self.test_hierarchy.get_compliance_test_cases()
@@ -1156,18 +1156,18 @@ class TestRunner:
         overall_compliance["Overall_Compliance_Level_Weighted_Grade"] = round((self.score_max / total_sum) * 100, 2) if total_sum != 0 else 0
      
     def test_result_summary(self, test_report, test_score_data):
-        """
+        r"""
         Append the current test result from the test cache to the overall test result summary.
-        """
+        r"""
         test_result_all_summary = test_score_data if self.consolidate and self.inside else self.test_all_cache
         result_summary = test_report["test_results"]
         result_summary.extend(test_result_all_summary)
         
         
     def add_missing_compliance_levels(self, test_report):
-        """
+        r"""
         Ensure all expected compliance levels are included (e.g.,L0, L1, L2, L3).
-        """         
+        r"""         
         domain_summary = test_report["domain_summary"]["domains"]
         all_domains = self.test_hierarchy.get_domains()
         for domain, value in all_domains.items():
@@ -1223,9 +1223,9 @@ class TestRunner:
         
                 
     def generate_full_log_from_summary(self):
-        """
+        r"""
         Generate a complete test report log file with all tables using the summary JSON file.
-        """
+        r"""
         try:
             if not self.test_summary_path:
                 raise FileNotFoundError("Test summary JSON file not found.")
@@ -1414,17 +1414,17 @@ class TestRunner:
             
             
     def seconds_to_time(self, seconds):
-        """
+        r"""
         Convert seconds to a formatted timedelta string.
-        """
+        r"""
         return str(timedelta(seconds=round(seconds, 3)))
     
     
     # --- Generic Table Printer ---
     def print_pretty_table(self, title, headers, rows, total_row=None):
-        """
+        r"""
         Generic method to create, print, and write a PrettyTable to the log file.
-        """
+        r"""
         try:
             table = PrettyTable(headers)
             table.title = title
@@ -1450,12 +1450,12 @@ class TestRunner:
   
   
     def get_system_details(self):
-        """
+        r"""
         Method to perform System Discovery
         
         :return: status_code, exit_string
         :rtype: int, str 
-        """
+        r"""
         try:
             self._start()
             status_code, exit_string = 0, "System discovery is done"
@@ -1512,9 +1512,9 @@ class TestRunner:
             return f"Failed to create Configuration folder or store files: {e}"
     
     def display_progress_bar(self):
-        """
+        r"""
         shows a real-time progress bar in the console displaying the percentage of test cases completed.
-        """
+        r"""
         with alive_bar(self.total_cases, title= "Progress:", spinner="arrow") as bar:
             count = 0
             while count < self.total_cases:
@@ -1620,7 +1620,7 @@ class TestRunner:
             return eval(expr)
 
     def resolve_and_load_spec_version(self, test_instance): 
-        """
+        r"""
         Determines and loads the appropriate specification version for the test case
         based on inputs from the command line, the test_runner.json file, and the
         versions supported by the test case itself.
@@ -1645,7 +1645,7 @@ class TestRunner:
                 (bool, str or None)
                 - bool: Indicates whether the spec version was successfully resolved and loaded.
                 - str or None: Error message if resolution fails, None otherwise.
-        """
+        r"""
         spec_support = getattr(test_instance, "spec_versions", None)
         spec_version = self.spec_version  
         spec_version = Version(spec_version) if spec_version else None
@@ -1694,7 +1694,7 @@ class TestRunner:
 
 
     def initialize_spec_path(self, spec_version=None):
-        """
+        r"""
         Initializes and sets the default path for the given specification version.
 
         Args:
@@ -1703,7 +1703,7 @@ class TestRunner:
         Notes:
             - Ensures the spec bindings are displayed only once.
             - Only prepares the path reference; it does not create or modify any files.
-        """
+        r"""
         self.default_config_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "json_spec", "input", f"spec_{spec_version}")
         self.default_config_path = self.default_config_path.replace('/tmp/', '') if self.default_config_path.startswith('/tmp/') else self.default_config_path
         if not self.show_spec_bindings:

--- a/ctam/test_runner.py
+++ b/ctam/test_runner.py
@@ -383,6 +383,11 @@ class TestRunner:
         :return: status_code, exit_string
         :rtype: int, str 
         r"""
+
+        status_code = -1        # default failure
+        exit_string = ""        # always defined
+        self._executed_any_test = False
+
         try:
             status_code = 0
             self.create_json_configuration()
@@ -549,6 +554,14 @@ class TestRunner:
             if self.comp_tool_dut:
                 self.comp_tool_dut.clean_up()
             self.post_proces_logs(self.writer.log_file)
+            if not self._executed_any_test:
+                self.active_run.add_log(
+                    severity=LogSeverity.INFO,
+                    message=(
+                        "No runnable CTAM tests were executed for this "
+                        "platform; result is NA."
+                    )
+                )
             return status_code, exit_string
         
     def consolidate_run(self):
@@ -778,6 +791,7 @@ class TestRunner:
                         # Inject measurements into all test cases
                         test_instance.measurements = self.measurements
                         test_result, failure_reason = test_instance.run()
+                        self._executed_any_test = True
                         if (
                             test_result == TestResult.FAIL
                         ):  # if any test fails, the group fails
@@ -1456,6 +1470,8 @@ class TestRunner:
         :return: status_code, exit_string
         :rtype: int, str 
         r"""
+        status_code = -1
+        exit_string = ""
         try:
             self._start()
             status_code, exit_string = 0, "System discovery is done"

--- a/ctam/test_runner.py
+++ b/ctam/test_runner.py
@@ -129,7 +129,9 @@ class TestRunner:
         self.redfish_response_messages = {}
         self.default_config_path = default_config_path
         self.show_spec_bindings = False
-        self.measurements = {}  
+        self.measurements = {}
+        self.writer = None
+        self.active_run = None
     
         if self.default_config_path:
             self._show_spec_bindings()
@@ -375,7 +377,19 @@ class TestRunner:
 
             elif tag in testcase.compliance_level:
                 testcase.score_weight = self.weighted_scores[tag]
-            
+
+    def _init_writer(self):
+        if self.writer is None:
+            self.writer = LoggingWriter(
+                self.output_dir,
+                self.console_log,
+                "OCPTV_CTAM_LOGS_",
+                "json",
+                self.debug_mode,
+                desanitize_log=self.sanitize_logs,
+                words_to_skip=self.words_to_skip
+            )
+
     def run(self):
         r"""
         Public API used to kick of the test suite
@@ -387,6 +401,8 @@ class TestRunner:
         status_code = -1        # default failure
         exit_string = ""        # always defined
         self._executed_any_test = False
+        gtotal = 0            # ensure initialized
+        self._init_writer()
 
         try:
             status_code = 0

--- a/ctam/test_runner.py
+++ b/ctam/test_runner.py
@@ -42,6 +42,9 @@ from utils.logger_utils import LoggingWriter, LogSanitizer, BuiltInLogSanitizers
 from version import __version__
 COUNTER = 0   
 
+class _NullActiveRun:
+    def add_log(self, *args, **kwargs):
+        pass
 
 class TestRunner:
     r"""
@@ -403,6 +406,8 @@ class TestRunner:
         self._executed_any_test = False
         gtotal = 0            # ensure initialized
         self._init_writer()
+        if self.active_run is None:
+            self.active_run = _NullActiveRun()
 
         try:
             status_code = 0

--- a/ctam/tests/fw_update/fw_update_group_N/_fw_update_group_N.py
+++ b/ctam/tests/fw_update/fw_update_group_N/_fw_update_group_N.py
@@ -1,22 +1,22 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 
-"""
+r"""
 from typing import Optional, List
 from tests.test_group import TestGroup
 from interfaces.fw_update_ifc import FWUpdateIfc
 
 
 class FWUpdateTestGroupN(TestGroup):
-    """
+    r"""
     Checks basic status of the dut
 
     :param TestGroup: super class for all test groups
     :type TestGroup:
-    """
+    r"""
 
     tags: List[str] = []
     group_id : str = "GFW1"
@@ -24,24 +24,24 @@ class FWUpdateTestGroupN(TestGroup):
     # exclude_tags: List[str] = []
 
     def __init__(self):
-        """
+        r"""
         The test environment uses an auto discovery search and will instantiate all test groups and assign all of the
         group test cases to self.test_list[]   Since not all groups will be run, keep this init function minimal. Use
         configure_interfaces for most initialization
-        """
+        r"""
         super().__init__()
 
     def configure_interfaces(self, fw_ifc: FWUpdateIfc):
-        """
+        r"""
         See description for __init__() above. The framework uses lazy initialization.  This interfaces for this
         function are only instantiated if there are any test cases in this group that will be executed.
-        """
+        r"""
         self.fw_update_ifc = fw_ifc
 
     def setup(self):
-        """
+        r"""
         configure common environment state for all test cases in this group
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -51,9 +51,9 @@ class FWUpdateTestGroupN(TestGroup):
             pass
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup(), this function is called even if test cases fail or raise exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_activation_time.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_activation_time.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) NVIDIA CORPORATION
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -38,7 +38,7 @@ LICENSE file in the root directory of this source tree.
                             
         <redfish_response_messages.json>  : Required - <UpdateProgress_Message>
                                            Optional -  <LargeFWImageUpdate>
-"""
+r"""
 
 import os
 import json
@@ -58,12 +58,12 @@ from tests.fw_update.fw_update_group_N._fw_update_group_N import (
 
 
 class CTAMTestFullDeviceUpdateActivationTime(TestCase):
-    """
+    r"""
     Verify that firmware activation operation does not exceed the max time specified in the requirements
 
     :param TestCase: super class for all test cases
     :type TestCase:
-    """
+    r"""
 
     test_name: str = "CTAM Test Full Device Update Activation Time"
     test_id: str = "F64"
@@ -73,16 +73,16 @@ class CTAMTestFullDeviceUpdateActivationTime(TestCase):
     spec_versions: Union[str, List[str]] = ">= 1.0"
 
     def __init__(self, group: FWUpdateTestGroupN):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -92,9 +92,9 @@ class CTAMTestFullDeviceUpdateActivationTime(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
         result = True
         failure_reason = ""
         activation_time = None
@@ -214,9 +214,9 @@ class CTAMTestFullDeviceUpdateActivationTime(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_activation_with_failed_component.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_activation_with_failed_component.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) NVIDIA CORPORATION
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -40,7 +40,7 @@ LICENSE file in the root directory of this source tree.
                             
         <redfish_response_messages.json>  : Required - <UpdateProgress_Message>
                                            Optional -  <LargeFWImageUpdate>
-"""
+r"""
 
 from typing import Optional, List, Union
 from tests.test_case import TestCase
@@ -57,12 +57,12 @@ from tests.fw_update.fw_update_group_N._fw_update_group_N import (
 
 
 class CTAMTestFullDeviceUpdateActivationWithFailedComponent(TestCase):
-    """
+    r"""
     Verify If one component copying (staging) fails, activation is handled correctly.
 
     :param TestCase: super class for all test cases
     :type TestCase:
-    """
+    r"""
 
     test_name: str = "CTAM Test Full Device Update Activation With Failed Component"
     test_id: str = "F56"
@@ -72,17 +72,17 @@ class CTAMTestFullDeviceUpdateActivationWithFailedComponent(TestCase):
     spec_versions: Union[str, List[str]] = ">= 1.0"
 
     def __init__(self, group: FWUpdateTestGroupN):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
         self.corrupted_component_id = None
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -92,9 +92,9 @@ class CTAMTestFullDeviceUpdateActivationWithFailedComponent(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
         failure_reason = ""
         result = True
         
@@ -183,9 +183,9 @@ class CTAMTestFullDeviceUpdateActivationWithFailedComponent(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_in_loop.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_in_loop.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 Copyright (c) NVIDIA CORPORATION
 This source code is licensed under the MIT license found in the
@@ -34,7 +34,7 @@ LICENSE file in the root directory of this source tree.
                                                         
         <redfish_response_messages.json>  : Required - <UpdateProgress_Message>
                                            Optional -  <LargeFWImageUpdate>
-"""
+r"""
 from typing import Optional, List, Union
 from tests.test_case import TestCase
 from ocptv.output import (
@@ -49,12 +49,12 @@ from tests.fw_update.fw_update_group_N._fw_update_group_N import (
 )
 
 class CTAMTestFullDeviceUpdateInLoop(TestCase):
-    """
+    r"""
     Verify values of Software Inventory Collection are present
 
     :param TestCase: super class for all test cases
     :type TestCase:
-    """
+    r"""
 
     test_name: str = "CTAM Test Full Device Update In Loop"
     test_id: str = "F8"
@@ -64,16 +64,16 @@ class CTAMTestFullDeviceUpdateInLoop(TestCase):
     spec_versions: Union[str, List[str]] = ">= 1.0"
 
     def __init__(self, group: FWUpdateTestGroupN):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -83,7 +83,7 @@ class CTAMTestFullDeviceUpdateInLoop(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
 
         :Description: This method runs the test case which stages the firmware update, activates it, and verifies the update in a loop.
@@ -91,7 +91,7 @@ class CTAMTestFullDeviceUpdateInLoop(TestCase):
 
         :PASS Criteria: The test passes if all firmware updates complete successfully without errors in the loop.
         :FAIL Criteria: The test fails if any firmware update encounters an error in the loop.
-        """
+        r"""
         failure_reason = ""
         result = True
 
@@ -215,9 +215,9 @@ class CTAMTestFullDeviceUpdateInLoop(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_nocheck.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_nocheck.py
@@ -32,7 +32,7 @@ LICENSE file in the root directory of this source tree.
                             
         <redfish_response_messages.json>  : Required - <UpdateProgress_Message>
                                            Optional -  <LargeFWImageUpdate>
-"""
+r"""
 
 from typing import Optional, List, Union
 from tests.test_case import TestCase
@@ -49,12 +49,12 @@ from tests.fw_update.fw_update_group_N._fw_update_group_N import (
 
 
 class CTAMTestFullDeviceUpdateNoCheck(TestCase):
-    """
+    r"""
     Verify that full device update staging is successful followed by activation, no precheck and postcheck is performed in this test case.
 
     :param TestCase: super class for all test cases
     :type TestCase:
-    """
+    r"""
 
     test_name: str = "CTAM Test Full Device Update No Check"
     test_id: str = "F5"
@@ -64,16 +64,16 @@ class CTAMTestFullDeviceUpdateNoCheck(TestCase):
     spec_versions: Union[str, List[str]] = ">= 1.0"
 
     def __init__(self, group: FWUpdateTestGroupN):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -83,9 +83,9 @@ class CTAMTestFullDeviceUpdateNoCheck(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
         result = True
         failure_reason = ""
 
@@ -129,9 +129,9 @@ class CTAMTestFullDeviceUpdateNoCheck(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_ping_pong.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_ping_pong.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -33,7 +33,7 @@ LICENSE file in the root directory of this source tree.
                                                      
         <redfish_response_messages.json>  : Required - <UpdateProgress_Message>
                                            Optional -  <LargeFWImageUpdate>
-"""
+r"""
 from typing import Optional, List, Union
 from tests.test_case import TestCase
 from ocptv.output import (
@@ -49,12 +49,12 @@ from tests.fw_update.fw_update_group_N._fw_update_group_N import (
 
 
 class CTAMTestFullDeviceUpdatePingPong(TestCase):
-    """
+    r"""
     Verify values of Software Inventory Collection are present
 
     :param TestCase: super class for all test cases
     :type TestCase:
-    """
+    r"""
 
     test_name: str = "CTAM Test Full Device Update Ping Pong"
     test_id: str = "F88"
@@ -64,16 +64,16 @@ class CTAMTestFullDeviceUpdatePingPong(TestCase):
     spec_versions: Union[str, List[str]] = ">= 1.0"
 
     def __init__(self, group: FWUpdateTestGroupN):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -83,9 +83,9 @@ class CTAMTestFullDeviceUpdatePingPong(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
 
         result = True
         loops = 2
@@ -174,9 +174,9 @@ class CTAMTestFullDeviceUpdatePingPong(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_precheck_only.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_precheck_only.py
@@ -30,7 +30,7 @@ LICENSE file in the root directory of this source tree.
                             
         <redfish_response_messages.json>  : Required - <UpdateProgress_Message>
                                            Optional -  <LargeFWImageUpdate>
-"""
+r"""
 
 from typing import Optional, List, Union
 from tests.test_case import TestCase
@@ -47,12 +47,12 @@ from tests.fw_update.fw_update_group_N._fw_update_group_N import (
 
 
 class CTAMTestFullDeviceUpdatePrecheckOnly(TestCase):
-    """
+    r"""
     Verify that full device SoftwareInventory matches against new firmware
 
     :param TestCase: super class for all test cases
     :type TestCase:
-    """
+    r"""
 
     test_name: str = "CTAM Test Full Device Update Precheck Only"
     test_id: str = "F3"
@@ -62,16 +62,16 @@ class CTAMTestFullDeviceUpdatePrecheckOnly(TestCase):
     spec_versions: Union[str, List[str]] = ">= 1.0"
 
     def __init__(self, group: FWUpdateTestGroupN):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -81,9 +81,9 @@ class CTAMTestFullDeviceUpdatePrecheckOnly(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
         result = True
         failure_reason = ""
 
@@ -110,9 +110,9 @@ class CTAMTestFullDeviceUpdatePrecheckOnly(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_rollback.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_rollback.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -36,7 +36,7 @@ LICENSE file in the root directory of this source tree.
                                                        
         <redfish_response_messages.json>  : Required - <UpdateProgress_Message>
                                            Optional -  <LargeFWImageUpdate>
-"""
+r"""
 
 from typing import Optional, List, Union
 from tests.test_case import TestCase
@@ -53,12 +53,12 @@ from tests.fw_update.fw_update_group_N._fw_update_group_N import (
 
 
 class CTAMTestFullDeviceUpdateRollback(TestCase):
-    """
+    r"""
     Verify values of Software Inventory Collection are present
 
     :param TestCase: super class for all test cases
     :type TestCase:
-    """
+    r"""
 
     test_name: str = "CTAM Test Full Device Update Rollback"
     test_id: str = "F0"
@@ -68,16 +68,16 @@ class CTAMTestFullDeviceUpdateRollback(TestCase):
     spec_versions: Union[str, List[str]] = ">= 1.0"
 
     def __init__(self, group: FWUpdateTestGroupN):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -87,9 +87,9 @@ class CTAMTestFullDeviceUpdateRollback(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
         result = True
         failure_reason = ""
         step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
@@ -165,9 +165,9 @@ class CTAMTestFullDeviceUpdateRollback(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_staging_only.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_staging_only.py
@@ -30,7 +30,7 @@ LICENSE file in the root directory of this source tree.
                             
         <redfish_response_messages.json>  : Required - <UpdateProgress_Message>
                                            Optional -  <LargeFWImageUpdate>
-"""
+r"""
 
 from typing import Optional, List, Union
 from tests.test_case import TestCase
@@ -47,12 +47,12 @@ from tests.fw_update.fw_update_group_N._fw_update_group_N import (
 
 
 class CTAMTestFullDeviceUpdateStagingOnly(TestCase):
-    """
+    r"""
     Verify that full device update staging only successful, no precheck and postcheck is performed in this test case.
 
     :param TestCase: super class for all test cases
     :type TestCase:
-    """
+    r"""
 
     test_name: str = "CTAM Test Full Device Update Staging Only"
     test_id: str = "F2"
@@ -62,16 +62,16 @@ class CTAMTestFullDeviceUpdateStagingOnly(TestCase):
     spec_versions: Union[str, List[str]] = ">= 1.0"
 
     def __init__(self, group: FWUpdateTestGroupN):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -81,9 +81,9 @@ class CTAMTestFullDeviceUpdateStagingOnly(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
         result = True
         failure_reason = ""
 
@@ -110,9 +110,9 @@ class CTAMTestFullDeviceUpdateStagingOnly(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_staging_time.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_staging_time.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) NVIDIA CORPORATION
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -37,7 +37,7 @@ Description:
                                                       
         <redfish_response_messages.json>  : Required - <UpdateProgress_Message>
                                            Optional -  <LargeFWImageUpdate>
-"""
+r"""
 import os
 import json
 from typing import Optional, List, Union
@@ -55,12 +55,12 @@ from tests.fw_update.fw_update_group_N._fw_update_group_N import (
 
 
 class CTAMTestFullDeviceUpdateStagingTime(TestCase):
-    """
+    r"""
     Verfy that firmware copy operation (staging) does not exceed the max time specified in the requirements
 
     :param TestCase: super class for all test cases
     :type TestCase:
-    """
+    r"""
 
     test_name: str = "CTAM Test Full Device Update Staging Time"
     test_id: str = "F63"
@@ -70,16 +70,16 @@ class CTAMTestFullDeviceUpdateStagingTime(TestCase):
     spec_versions: Union[str, List[str]] = ">= 1.0"
 
     def __init__(self, group: FWUpdateTestGroupN):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -89,9 +89,9 @@ class CTAMTestFullDeviceUpdateStagingTime(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
         result = True
         failure_reason = ""
         staging_time = None
@@ -210,9 +210,9 @@ class CTAMTestFullDeviceUpdateStagingTime(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_staging_with_failed_component.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_staging_with_failed_component.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) NVIDIA CORPORATION
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -36,7 +36,7 @@ LICENSE file in the root directory of this source tree.
                                                        
         <redfish_response_messages.json>  : Required - <UpdateProgress_Message>
                                            Optional -  <LargeFWImageUpdate>
-"""
+r"""
 
 from typing import Optional, List, Union
 from tests.test_case import TestCase
@@ -53,12 +53,12 @@ from tests.fw_update.fw_update_group_N._fw_update_group_N import (
 
 
 class CTAMTestFullDeviceUpdateStagingWithFailedComponent(TestCase):
-    """
+    r"""
     Verify if one component copying (staging) fails, other component copying (staging) goes through.
 
     :param TestCase: super class for all test cases
     :type TestCase:
-    """
+    r"""
 
     test_name: str = "CTAM Test Full Device Update Staging With Failed Component"
     test_id: str = "F55"
@@ -68,17 +68,17 @@ class CTAMTestFullDeviceUpdateStagingWithFailedComponent(TestCase):
     spec_versions: Union[str, List[str]] = ">= 1.0"
 
     def __init__(self, group: FWUpdateTestGroupN):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
         self.corrupted_component_id = None
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -88,9 +88,9 @@ class CTAMTestFullDeviceUpdateStagingWithFailedComponent(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
         result = True
         failure_reason = ""
         step0 = self.test_run().add_step(f"{self.__class__.__name__} run(), step0")  # type: ignore
@@ -142,9 +142,9 @@ class CTAMTestFullDeviceUpdateStagingWithFailedComponent(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...step1")

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_with_older_version.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_with_older_version.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -38,7 +38,7 @@ LICENSE file in the root directory of this source tree.
                                                       
         <redfish_response_messages.json>  : Required - <UpdateProgress_Message>
                                            Optional -  <LargeFWImageUpdate>
-"""
+r"""
 
 from typing import Optional, List, Union
 from tests.test_case import TestCase
@@ -55,12 +55,12 @@ from tests.fw_update.fw_update_group_N._fw_update_group_N import (
 
 
 class CTAMTestFullDeviceUpdateWithOlderVersion(TestCase):
-    """
+    r"""
     Verify values of Software Inventory Collection are present
 
     :param TestCase: super class for all test cases
     :type TestCase:
-    """
+    r"""
 
     test_name: str = "CTAM Test Full Device Update With Older Version"
     test_id: str = "F19"
@@ -70,16 +70,16 @@ class CTAMTestFullDeviceUpdateWithOlderVersion(TestCase):
     spec_versions: Union[str, List[str]] = ">= 1.0"
 
     def __init__(self, group: FWUpdateTestGroupN):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -89,9 +89,9 @@ class CTAMTestFullDeviceUpdateWithOlderVersion(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
 
         result = True
         image_t = "old_version"
@@ -174,9 +174,9 @@ class CTAMTestFullDeviceUpdateWithOlderVersion(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_corrupt_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_corrupt_image_update.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -38,7 +38,7 @@ LICENSE file in the root directory of this source tree.
                                                       
         <redfish_response_messages.json>  : Required - <UpdateProgress_Message>
                                            Optional -  <LargeFWImageUpdate>
-"""
+r"""
 
 from typing import Optional, List, Union
 from tests.test_case import TestCase
@@ -55,12 +55,12 @@ from tests.fw_update.fw_update_group_N._fw_update_group_N import (
 
 
 class CTAMTestNegativeCorruptImageUpdate(TestCase):
-    """
+    r"""
     Verify values of Software Inventory Collection are present
 
     :param TestCase: super class for all test cases
     :type TestCase:
-    """
+    r"""
 
     test_name: str = "CTAM Test Negative Corrupt Image Update"
     test_id: str = "F23"
@@ -70,16 +70,16 @@ class CTAMTestNegativeCorruptImageUpdate(TestCase):
     spec_versions: Union[str, List[str]] = ">= 1.0"
 
     def __init__(self, group: FWUpdateTestGroupN):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -89,9 +89,9 @@ class CTAMTestNegativeCorruptImageUpdate(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
         result = True
         failure_reason = ""
 
@@ -133,9 +133,9 @@ class CTAMTestNegativeCorruptImageUpdate(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope(): 

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_empty_metadata_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_empty_metadata_image_update.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) NVIDIA CORPORATION
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -38,7 +38,7 @@ LICENSE file in the root directory of this source tree.
                                                       
         <redfish_response_messages.json>  : Required - <UpdateProgress_Message>
                                            Optional -  <LargeFWImageUpdate>
-"""
+r"""
 
 from typing import Optional, List, Union
 from tests.test_case import TestCase
@@ -55,12 +55,12 @@ from tests.fw_update.fw_update_group_N._fw_update_group_N import (
 
 
 class CTAMTestNegativeEmptyMetadataImageUpdate(TestCase):
-    """
+    r"""
     Verify values of Software Inventory Collection are present
 
     :param TestCase: super class for all test cases
     :type TestCase:
-    """
+    r"""
 
     test_name: str = "CTAM Test Negative Empty Metadata Image Update"
     test_id: str = "F26"
@@ -70,16 +70,16 @@ class CTAMTestNegativeEmptyMetadataImageUpdate(TestCase):
     spec_versions: Union[str, List[str]] = ">= 1.0"
 
     def __init__(self, group: FWUpdateTestGroupN):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -89,9 +89,9 @@ class CTAMTestNegativeEmptyMetadataImageUpdate(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
         result = True
         failure_reason = ""
 
@@ -149,9 +149,9 @@ class CTAMTestNegativeEmptyMetadataImageUpdate(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown(), Step1")
         with step1.scope():

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_full_device_update_staging_interruption_with_ac_reset.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_full_device_update_staging_interruption_with_ac_reset.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) NVIDIA CORPORATION
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -40,7 +40,7 @@ LICENSE file in the root directory of this source tree.
                                                       
         <redfish_response_messages.json>  : Required - <UpdateProgress_Message>
                                            Optional -  <LargeFWImageUpdate>
-"""
+r"""
 from typing import Optional, List, Union
 from tests.test_case import TestCase
 from ocptv.output import (
@@ -56,12 +56,12 @@ from tests.fw_update.fw_update_group_N._fw_update_group_N import (
 
 
 class CTAMTestFullDeviceUpdateStagingInterruptionWithAcReset(TestCase):
-    """
+    r"""
     Verify single device fails whhen a full device fw update staging is in progress
 
     :param TestCase: super class for all test cases
     :type TestCase:
-    """
+    r"""
 
     test_name: str = "CTAM Test Negative Full Device Update Staging Interruption With AC Reset"
     test_id: str = "F24"
@@ -71,16 +71,16 @@ class CTAMTestFullDeviceUpdateStagingInterruptionWithAcReset(TestCase):
     spec_versions: Union[str, List[str]] = ">= 1.0"
 
     def __init__(self, group: FWUpdateTestGroupN):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -90,9 +90,9 @@ class CTAMTestFullDeviceUpdateStagingInterruptionWithAcReset(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
         failure_reason = ""
         result = True
         fwupd_task_id = None
@@ -167,9 +167,9 @@ class CTAMTestFullDeviceUpdateStagingInterruptionWithAcReset(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_device_uuid_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_device_uuid_image_update.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) NVIDIA CORPORATION
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -38,7 +38,7 @@ LICENSE file in the root directory of this source tree.
                                                       
         <redfish_response_messages.json>  : Required - <UpdateProgress_Message>
                                            Optional -  <LargeFWImageUpdate>
-"""
+r"""
 
 from typing import Optional, List, Union
 from tests.test_case import TestCase
@@ -55,12 +55,12 @@ from tests.fw_update.fw_update_group_N._fw_update_group_N import (
 
 
 class CTAMTestNegativeInvalidDeviceUUIDImageUpdate(TestCase):
-    """
+    r"""
     Verify values of Software Inventory Collection are present
 
     :param TestCase: super class for all test cases
     :type TestCase:
-    """
+    r"""
 
     test_name: str = "CTAM Test Negative Invalid Device UUID Image Update"
     test_id: str = "F28"
@@ -70,16 +70,16 @@ class CTAMTestNegativeInvalidDeviceUUIDImageUpdate(TestCase):
     spec_versions: Union[str, List[str]] = ">= 1.0"
 
     def __init__(self, group: FWUpdateTestGroupN):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -89,9 +89,9 @@ class CTAMTestNegativeInvalidDeviceUUIDImageUpdate(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
         failure_reason = ""
         result = True
 
@@ -133,9 +133,9 @@ class CTAMTestNegativeInvalidDeviceUUIDImageUpdate(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_package_uuid_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_package_uuid_image_update.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) NVIDIA CORPORATION
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -37,7 +37,7 @@ LICENSE file in the root directory of this source tree.
                                                       
         <redfish_response_messages.json>  : Required - <UpdateProgress_Message>
                                            Optional -  <LargeFWImageUpdate>
-"""
+r"""
 
 from typing import Optional, List, Union
 from tests.test_case import TestCase
@@ -54,12 +54,12 @@ from tests.fw_update.fw_update_group_N._fw_update_group_N import (
 
 
 class CTAMTestNegativeInvalidPackageUUIDImageUpdate(TestCase):
-    """
+    r"""
     Verify values of Software Inventory Collection are present
 
     :param TestCase: super class for all test cases
     :type TestCase:
-    """
+    r"""
 
     test_name: str = "CTAM Test Negative Invalid Package UUID Image Update"
     test_id: str = "F27"
@@ -69,16 +69,16 @@ class CTAMTestNegativeInvalidPackageUUIDImageUpdate(TestCase):
     spec_versions: Union[str, List[str]] = ">= 1.0"
 
     def __init__(self, group: FWUpdateTestGroupN):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -88,9 +88,9 @@ class CTAMTestNegativeInvalidPackageUUIDImageUpdate(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
         failure_reason = ""
         result = True
 
@@ -132,9 +132,9 @@ class CTAMTestNegativeInvalidPackageUUIDImageUpdate(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_signed_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_signed_image_update.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -36,7 +36,7 @@ LICENSE file in the root directory of this source tree.
                                                       
         <redfish_response_messages.json>  : Required - <UpdateProgress_Message>
                                            Optional -  <LargeFWImageUpdate>
-"""
+r"""
 
 from typing import Optional, List, Union
 from tests.test_case import TestCase
@@ -53,12 +53,12 @@ from tests.fw_update.fw_update_group_N._fw_update_group_N import (
 
 
 class CTAMTestNegativeInvalidSignedImageUpdate(TestCase):
-    """
+    r"""
     Verify values of Software Inventory Collection are present
 
     :param TestCase: super class for all test cases
     :type TestCase:
-    """
+    r"""
 
     test_name: str = "CTAM Test Negative Invalid Signed Image Update"
     test_id: str = "F22"
@@ -68,16 +68,16 @@ class CTAMTestNegativeInvalidSignedImageUpdate(TestCase):
     spec_versions: Union[str, List[str]] = ">= 1.0"
 
     def __init__(self, group: FWUpdateTestGroupN):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -87,9 +87,9 @@ class CTAMTestNegativeInvalidSignedImageUpdate(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
         failure_reason = ""
         result = True
 
@@ -131,9 +131,9 @@ class CTAMTestNegativeInvalidSignedImageUpdate(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope(): 

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_large_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_large_image_update.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -37,7 +37,7 @@ LICENSE file in the root directory of this source tree.
                                                       
         <redfish_response_messages.json>  : Required - <UpdateProgress_Message>
                                            Optional -  <LargeFWImageUpdate>
-"""
+r"""
 from typing import Optional, List, Union
 from tests.test_case import TestCase
 from ocptv.output import (
@@ -52,12 +52,12 @@ from tests.fw_update.fw_update_group_N._fw_update_group_N import (
 )
 
 class CTAMTestNegativeLargeImageUpdate(TestCase):
-    """
+    r"""
     Verify values of Software Inventory Collection are present
 
     :param TestCase: super class for all test cases
     :type TestCase:
-    """
+    r"""
 
     test_name: str = "CTAM Test Negative Large Image Update"
     test_id: str = "F25"
@@ -67,16 +67,16 @@ class CTAMTestNegativeLargeImageUpdate(TestCase):
     spec_versions: Union[str, List[str]] = ">= 1.0"
 
     def __init__(self, group: FWUpdateTestGroupN):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -86,9 +86,9 @@ class CTAMTestNegativeLargeImageUpdate(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
         result = True
 
         step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
@@ -126,9 +126,9 @@ class CTAMTestNegativeLargeImageUpdate(TestCase):
         return self.result, status_msg
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_single_device_update_with_illegal_targets.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_single_device_update_with_illegal_targets.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -38,7 +38,7 @@ LICENSE file in the root directory of this source tree.
                                                       
         <redfish_response_messages.json>  : Required - <UpdateProgress_Message>
                                            Optional -  <LargeFWImageUpdate>
-"""
+r"""
 from typing import Optional, List, Union
 from tests.test_case import TestCase
 from ocptv.output import (
@@ -53,12 +53,12 @@ from tests.fw_update.fw_update_group_N._fw_update_group_N import (
 )
 
 class CTAMTestNegativeSingleDeviceUpdateWithIllegalTargets(TestCase):
-    """
+    r"""
     Test case to attempt update of targets which are not updateable. 
 
     :param TestCase: super class for all test cases
     :type TestCase:
-    """
+    r"""
 
     test_name: str = "CTAM Test Negative Single Device Update with illegal targets"
     test_id: str = "F32"
@@ -68,17 +68,17 @@ class CTAMTestNegativeSingleDeviceUpdateWithIllegalTargets(TestCase):
     spec_versions: Union[str, List[str]] = ">= 1.0"
 
     def __init__(self, group: FWUpdateTestGroupN):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
         self.exclude_targets = []
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -88,9 +88,9 @@ class CTAMTestNegativeSingleDeviceUpdateWithIllegalTargets(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
         result = True
         failure_reason = ""
 
@@ -181,9 +181,9 @@ class CTAMTestNegativeSingleDeviceUpdateWithIllegalTargets(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_single_fw_update_staging_interruption_with_ac_reset.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_single_fw_update_staging_interruption_with_ac_reset.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -38,7 +38,7 @@ LICENSE file in the root directory of this source tree.
                                                       
         <redfish_response_messages.json>  : Required - <UpdateProgress_Message>
                                            Optional -  <LargeFWImageUpdate>
-"""
+r"""
 import ast
 from typing import Optional, List, Union
 from tests.test_case import TestCase
@@ -54,12 +54,12 @@ from tests.fw_update.fw_update_group_N._fw_update_group_N import (
 )
 
 class CTAMTestSingleFWUpdateStagingInterruptionWithACReset(TestCase):
-    """
+    r"""
     Verify values of Software Inventory Collection are present
 
     :param TestCase: super class for all test cases
     :type TestCase:
-    """
+    r"""
 
     test_name: str = "CTAM Test Single FW update staging interruption with AC reset"
     test_id: str = "F62"
@@ -69,16 +69,16 @@ class CTAMTestSingleFWUpdateStagingInterruptionWithACReset(TestCase):
     spec_versions: Union[str, List[str]] = ">= 1.0"
 
     def __init__(self, group: FWUpdateTestGroupN):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -88,9 +88,9 @@ class CTAMTestSingleFWUpdateStagingInterruptionWithACReset(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
         result = True
         failure_reason = ""
 
@@ -165,9 +165,9 @@ class CTAMTestSingleFWUpdateStagingInterruptionWithACReset(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_unsigned_bundle_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_unsigned_bundle_update.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) NVIDIA CORPORATION
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -37,7 +37,7 @@ LICENSE file in the root directory of this source tree.
                                                       
         <redfish_response_messages.json>  : Required - <UpdateProgress_Message>
                                            Optional -  <LargeFWImageUpdate>
-"""
+r"""
 
 from typing import Optional, List, Union
 from tests.test_case import TestCase
@@ -54,12 +54,12 @@ from tests.fw_update.fw_update_group_N._fw_update_group_N import (
 
 
 class CTAMTestNegativeUnsignedBundleUpdate(TestCase):
-    """
+    r"""
     Test case which attempts an Unsigned Bundle update
 
     :param TestCase: super class for all test cases
     :type TestCase:
-    """
+    r"""
 
     test_name: str = "CTAM Test Negative Unsigned Bundle Update"
     test_id: str = "F90"
@@ -69,16 +69,16 @@ class CTAMTestNegativeUnsignedBundleUpdate(TestCase):
     spec_versions: Union[str, List[str]] = ">= 1.0"
 
     def __init__(self, group: FWUpdateTestGroupN):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -88,9 +88,9 @@ class CTAMTestNegativeUnsignedBundleUpdate(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
         failure_reason = ""
         result = True
 
@@ -133,9 +133,9 @@ class CTAMTestNegativeUnsignedBundleUpdate(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_unsigned_component_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_unsigned_component_image_update.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -36,7 +36,7 @@ LICENSE file in the root directory of this source tree.
                                                       
         <redfish_response_messages.json>  : Required - <UpdateProgress_Message>
                                            Optional -  <LargeFWImageUpdate>
-"""
+r"""
 
 from typing import Optional, List, Union
 from tests.test_case import TestCase
@@ -53,12 +53,12 @@ from tests.fw_update.fw_update_group_N._fw_update_group_N import (
 
 
 class CTAMTestNegativeUnsignedImageUpdate(TestCase):
-    """
+    r"""
     Test case which attempts an unsigned image update
 
     :param TestCase: super class for all test cases
     :type TestCase:
-    """
+    r"""
 
     test_name: str = "CTAM Test Negative Unsigned Image Update"
     test_id: str = "F18"
@@ -68,16 +68,16 @@ class CTAMTestNegativeUnsignedImageUpdate(TestCase):
     spec_versions: Union[str, List[str]] = ">= 1.0"
 
     def __init__(self, group: FWUpdateTestGroupN):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -87,9 +87,9 @@ class CTAMTestNegativeUnsignedImageUpdate(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
         failure_reason = ""
         result = True
 
@@ -130,9 +130,9 @@ class CTAMTestNegativeUnsignedImageUpdate(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_single_device_update_ping_pong.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_single_device_update_ping_pong.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -36,7 +36,7 @@ LICENSE file in the root directory of this source tree.
                                                       
         <redfish_response_messages.json>  : Required - <UpdateProgress_Message>
                                            Optional -  <LargeFWImageUpdate>
-"""
+r"""
 import ast
 from typing import Optional, List, Union
 from tests.test_case import TestCase
@@ -52,12 +52,12 @@ from tests.fw_update.fw_update_group_N._fw_update_group_N import (
 )
 
 class CTAMTestSingleDeviceUpdatePingPong(TestCase):
-    """
+    r"""
     Verify values of Software Inventory Collection are present
 
     :param TestCase: super class for all test cases
     :type TestCase:
-    """
+    r"""
 
     test_name: str = "CTAM Test Single Device Update Ping Pong"
     test_id: str = "F89"
@@ -67,18 +67,18 @@ class CTAMTestSingleDeviceUpdatePingPong(TestCase):
     spec_versions: Union[str, List[str]] = ">= 1.0"
 
     def __init__(self, group: FWUpdateTestGroupN):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
         self.specific_targets = []
         self.excluded_targets = []
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -88,9 +88,9 @@ class CTAMTestSingleDeviceUpdatePingPong(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
         result = True
         loops = 2
         failure_reason = ""
@@ -169,9 +169,9 @@ class CTAMTestSingleDeviceUpdatePingPong(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown(), Step1")
         with step1.scope():

--- a/ctam/tests/fw_update/fw_update_group_N_1/_fw_update_group_N_1.py
+++ b/ctam/tests/fw_update/fw_update_group_N_1/_fw_update_group_N_1.py
@@ -1,22 +1,22 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 
-"""
+r"""
 from typing import Optional, List
 from tests.test_group import TestGroup
 from interfaces.fw_update_ifc import FWUpdateIfc
 
 
 class FWUpdateTestGroupNMinus1(TestGroup):
-    """
+    r"""
     Checks basic status of the dut
 
     :param TestGroup: super class for all test groups
     :type TestGroup:
-    """
+    r"""
 
     tags: List[str] = []
     group_id : str = "GFW2"
@@ -24,24 +24,24 @@ class FWUpdateTestGroupNMinus1(TestGroup):
     # exclude_tags: List[str] = []
 
     def __init__(self):
-        """
+        r"""
         The test environment uses an auto discovery search and will instantiate all test groups and assign all of the
         group test cases to self.test_list[]   Since not all groups will be run, keep this init function minimal. Use
         configure_interfaces for most initialization
-        """
+        r"""
         super().__init__()
 
     def configure_interfaces(self, fw_ifc: FWUpdateIfc):
-        """
+        r"""
         See description for __init__() above. The framework uses lazy initialization.  This interfaces for this
         function are only instantiated if there are any test cases in this group that will be executed.
-        """
+        r"""
         self.fw_update_ifc = fw_ifc
 
     def setup(self):
-        """
+        r"""
         configure common environment state for all test cases in this group
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -51,9 +51,9 @@ class FWUpdateTestGroupNMinus1(TestGroup):
             pass
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup(), this function is called even if test cases fail or raise exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_full_device_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_full_device_update.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -35,7 +35,7 @@ LICENSE file in the root directory of this source tree.
                                                         
         <redfish_response_messages.json>  : Required - <UpdateProgress_Message>
                                            Optional -  <LargeFWImageUpdate>
-"""
+r"""
 import os
 import json
 from typing import Optional, List, Union
@@ -53,12 +53,12 @@ from tests.fw_update.fw_update_group_N_1._fw_update_group_N_1 import (
 
 
 class CTAMTestFullDeviceUpdate(TestCase):
-    """
+    r"""
     Verify values of Software Inventory Collection are present
 
     :param TestCase: super class for all test cases
     :type TestCase:
-    """
+    r"""
 
     test_name: str = "CTAM Test Full Device Update"
     test_id: str = "F1"
@@ -68,16 +68,16 @@ class CTAMTestFullDeviceUpdate(TestCase):
     spec_versions: Union[str, List[str]] = ">= 1.0"
 
     def __init__(self, group: FWUpdateTestGroupNMinus1):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -87,9 +87,9 @@ class CTAMTestFullDeviceUpdate(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
         result = True
         failure_reason = ""
         step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
@@ -162,9 +162,9 @@ class CTAMTestFullDeviceUpdate(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_install_same_image_two_times.py
+++ b/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_install_same_image_two_times.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -37,7 +37,7 @@ LICENSE file in the root directory of this source tree.
         <redfish_response_messages.json>  : Required - <UpdateProgress_Message>
                                            Optional -  <LargeFWImageUpdate>
 
-"""
+r"""
 
 from typing import Optional, List, Union
 from tests.test_case import TestCase
@@ -54,12 +54,12 @@ from tests.fw_update.fw_update_group_N_1._fw_update_group_N_1 import (
 
 
 class CTAMTestInstallSameImageTwoTimes(TestCase):
-    """
+    r"""
     Verify values of Software Inventory Collection are present
 
     :param TestCase: super class for all test cases
     :type TestCase:
-    """
+    r"""
 
     test_name: str = "CTAM Test Install Same Image Two Times"
     test_id: str = "F16"
@@ -69,16 +69,16 @@ class CTAMTestInstallSameImageTwoTimes(TestCase):
     spec_versions: Union[str, List[str]] = ">= 1.0"
 
     def __init__(self, group: FWUpdateTestGroupNMinus1):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -88,9 +88,9 @@ class CTAMTestInstallSameImageTwoTimes(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
 
         result = True
         times = 2
@@ -173,9 +173,9 @@ class CTAMTestInstallSameImageTwoTimes(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_single_device_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_single_device_update.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -36,7 +36,7 @@ LICENSE file in the root directory of this source tree.
                                                         
         <redfish_response_messages.json>  : Required - <UpdateProgress_Message>
                                            Optional -  <LargeFWImageUpdate>
-"""
+r"""
 
 from typing import Optional, List, Union
 from tests.test_case import TestCase
@@ -52,12 +52,12 @@ from tests.fw_update.fw_update_group_N_1._fw_update_group_N_1 import (
 )
 
 class CTAMTestSingleDeviceUpdate(TestCase):
-    """
+    r"""
     Verify values of Software Inventory Collection are present
 
     :param TestCase: super class for all test cases
     :type TestCase:
-    """
+    r"""
 
     test_name: str = "CTAM Test Single Device Update"
     test_id: str = "F4"
@@ -67,16 +67,16 @@ class CTAMTestSingleDeviceUpdate(TestCase):
     spec_versions: Union[str, List[str]] = ">= 1.0"
 
     def __init__(self, group: FWUpdateTestGroupNMinus1):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -86,9 +86,9 @@ class CTAMTestSingleDeviceUpdate(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
         result = True
         updated_devices = []
         failed_devices = []
@@ -192,9 +192,9 @@ class CTAMTestSingleDeviceUpdate(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/health_check/basic_health_check_group/basic_health_check_test_group.py
+++ b/ctam/tests/health_check/basic_health_check_group/basic_health_check_test_group.py
@@ -1,22 +1,22 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 
-"""
+r"""
 from typing import Optional, List
 from tests.test_group import TestGroup
 from interfaces.health_check_ifc import HealthCheckIfc
 
 
 class BasicHealthCheckTestGroup(TestGroup):
-    """
+    r"""
     Checks basic status of the dut
 
     :param TestGroup: super class for all test groups
     :type TestGroup:
-    """
+    r"""
 
     tags: List[str] = []
     group_id : str = "GH1"
@@ -24,24 +24,24 @@ class BasicHealthCheckTestGroup(TestGroup):
     # exclude_tags: List[str] = []
 
     def __init__(self):
-        """
+        r"""
         The test environment uses an auto discovery search and will instantiate all test groups and assign all of the
         group test cases to self.test_list[]   Since not all groups will be run, keep this init function minimal. Use
         configure_interfaces for most initialization
-        """
+        r"""
         super().__init__()
 
     def configure_interfaces(self, hc_ifc: HealthCheckIfc):
-        """
+        r"""
         See description for __init__() above. The framework uses lazy initialization.  This interfaces for this
         function are only instantiated if there are any test cases in this group that will be executed.
-        """
+        r"""
         self.health_check_ifc = hc_ifc
 
     def setup(self):
-        """
+        r"""
         configure common environment state for all test cases in this group
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -51,9 +51,9 @@ class BasicHealthCheckTestGroup(TestGroup):
             pass
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup(), this function is called even if test cases fail or raise exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_logservice_dump_uri_list_read.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_logservice_dump_uri_list_read.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -29,7 +29,7 @@ FAIL Criteria:
 
 :Dependencies: None
                         
-"""
+r"""
 from typing import Optional, List, Union
 from tests.test_case import TestCase
 from pprint import pprint
@@ -45,12 +45,12 @@ from tests.health_check.basic_health_check_group.basic_health_check_test_group i
 )
 
 class CTAMTestLogServiceDumpURIListRead(TestCase):
-    """
+    r"""
         :param gpu_bb acc:		Accelerator Object
         :param Logger logger:	Logger Object
 
         :returns:				Test result [Pass/Fail], Test score
-    """
+    r"""
 
     test_name: str = "CTAM Test LogService Dump URI List Read"
     test_id: str = "H97"
@@ -60,16 +60,16 @@ class CTAMTestLogServiceDumpURIListRead(TestCase):
     spec_versions: Union[str, List[str]] = ">= 1.0"
 
     def __init__(self, group: BasicHealthCheckTestGroup):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -79,9 +79,9 @@ class CTAMTestLogServiceDumpURIListRead(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
         failure_reason = ""
         result = True
         step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
@@ -121,9 +121,9 @@ class CTAMTestLogServiceDumpURIListRead(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_logservice_uri_list_read.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_logservice_uri_list_read.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -23,7 +23,7 @@ LICENSE file in the root directory of this source tree.
 
 :Dependencies: None
                      
-"""
+r"""
 from typing import Optional, List, Union
 from tests.test_case import TestCase
 from pprint import pprint
@@ -40,12 +40,12 @@ from tests.health_check.basic_health_check_group.basic_health_check_test_group i
 
 
 class CTAMTestLogServicesURIListRead(TestCase):
-    """
+    r"""
         :param gpu_bb acc:		Accelerator Object
         :param Logger logger:	Logger Object
 
         :returns:				Test result [Pass/Fail], Test score
-    """
+    r"""
 
     test_name: str = "CTAM Test LogServices URI List Read"
     test_id: str = "H99"
@@ -55,16 +55,16 @@ class CTAMTestLogServicesURIListRead(TestCase):
     spec_versions: Union[str, List[str]] = ">= 1.0"
 
     def __init__(self, group: BasicHealthCheckTestGroup):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -74,9 +74,9 @@ class CTAMTestLogServicesURIListRead(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
         failure_reason = ""
         result = True
         step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
@@ -115,9 +115,9 @@ class CTAMTestLogServicesURIListRead(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_event_service.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_event_service.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -22,7 +22,7 @@ LICENSE file in the root directory of this source tree.
 
 :Dependencies: None
 
-"""
+r"""
 from typing import Optional, List, Union
 from tests.test_case import TestCase
 from ocptv.output import (
@@ -38,12 +38,12 @@ from tests.health_check.basic_health_check_group.basic_health_check_test_group i
 
 
 class CTAMTestRedfishEventService(TestCase):
-    """
+    r"""
     Verify the output of Event Service
 
     :param TestCase: super class for all test cases
     :type TestCase:
-    """
+    r"""
 
     test_name: str = "CTAM Test Redfish Event Service"
     test_id: str = "H8"
@@ -55,16 +55,16 @@ class CTAMTestRedfishEventService(TestCase):
     # exclude_tags: List[str] = ["NotCheck"]
 
     def __init__(self, group: BasicHealthCheckTestGroup):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -74,9 +74,9 @@ class CTAMTestRedfishEventService(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
         result = True
         failure_reason = ""
         step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
@@ -99,9 +99,9 @@ class CTAMTestRedfishEventService(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_event_service_create_subscription.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_event_service_create_subscription.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -22,7 +22,7 @@ LICENSE file in the root directory of this source tree.
 
 :Dependencies: None
 
-"""
+r"""
 from typing import Optional, List, Union
 from tests.test_case import TestCase
 from ocptv.output import (
@@ -38,12 +38,12 @@ from tests.health_check.basic_health_check_group.basic_health_check_test_group i
 
 
 class CTAMTestRedfishEventServiceCreateSubscription(TestCase):
-    """
+    r"""
     Verify the output of Event Service
 
     :param TestCase: super class for all test cases
     :type TestCase:
-    """
+    r"""
 
     test_name: str = "CTAM Test Redfish Event Service Create Subscription"
     test_id: str = "H83"
@@ -55,16 +55,16 @@ class CTAMTestRedfishEventServiceCreateSubscription(TestCase):
     # exclude_tags: List[str] = ["NotCheck"]
 
     def __init__(self, group: BasicHealthCheckTestGroup):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -74,9 +74,9 @@ class CTAMTestRedfishEventServiceCreateSubscription(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
         result = True
         failure_reason = ""
         step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
@@ -103,9 +103,9 @@ class CTAMTestRedfishEventServiceCreateSubscription(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_event_service_delete_subscription.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_event_service_delete_subscription.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -22,7 +22,7 @@ LICENSE file in the root directory of this source tree.
 
 :Dependencies: None
 
-"""
+r"""
 from typing import Optional, List, Union
 from tests.test_case import TestCase
 from ocptv.output import (
@@ -38,12 +38,12 @@ from tests.health_check.basic_health_check_group.basic_health_check_test_group i
 
 
 class CTAMTestRedfishEventServiceDeleteSubscription(TestCase):
-    """
+    r"""
     Delete all/Specific Event Service Subscription
 
     :param TestCase: super class for all test cases
     :type TestCase:
-    """
+    r"""
 
     test_name: str = "CTAM Test Redfish Event Service Delete Subscriptions"
     test_id: str = "H81"
@@ -55,16 +55,16 @@ class CTAMTestRedfishEventServiceDeleteSubscription(TestCase):
     # exclude_tags: List[str] = ["NotCheck"]
 
     def __init__(self, group: BasicHealthCheckTestGroup):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -74,9 +74,9 @@ class CTAMTestRedfishEventServiceDeleteSubscription(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
         result = True
         failure_reason = ""
         step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
@@ -98,9 +98,9 @@ class CTAMTestRedfishEventServiceDeleteSubscription(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_event_service_list_subscription.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_event_service_list_subscription.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -22,7 +22,7 @@ LICENSE file in the root directory of this source tree.
 
 :Dependencies: None
 
-"""
+r"""
 from typing import Optional, List, Union
 from tests.test_case import TestCase
 from ocptv.output import (
@@ -38,12 +38,12 @@ from tests.health_check.basic_health_check_group.basic_health_check_test_group i
 
 
 class CTAMTestRedfishEventServiceSubscription(TestCase):
-    """
+    r"""
     List all Event Service Subscription
 
     :param TestCase: super class for all test cases
     :type TestCase:
-    """
+    r"""
 
     test_name: str = "CTAM Test Redfish Event Service List Subscriptions"
     test_id: str = "H80"
@@ -55,16 +55,16 @@ class CTAMTestRedfishEventServiceSubscription(TestCase):
     # exclude_tags: List[str] = ["NotCheck"]
 
     def __init__(self, group: BasicHealthCheckTestGroup):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -74,9 +74,9 @@ class CTAMTestRedfishEventServiceSubscription(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
         result = True
         failure_reason = ""
         step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
@@ -100,9 +100,9 @@ class CTAMTestRedfishEventServiceSubscription(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_firmware_inventory_collection.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_firmware_inventory_collection.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -22,7 +22,7 @@ LICENSE file in the root directory of this source tree.
 
 :Dependencies: None
 
-"""
+r"""
 from typing import Optional, List, Union
 from tests.test_case import TestCase
 from test_hierarchy import TestHierarchy
@@ -41,12 +41,12 @@ from utils.ctam_utils import GitUtils
 from interfaces.functional_ifc import FunctionalIfc
 
 class CTAMTestRedfishInteropValidatorFirmwareInventory(TestCase):
-    """
+    r"""
     Verify values of Firmware Inventory Collection are present
 
     :param TestCase: super class for all test cases
     :type TestCase:
-    """
+    r"""
 
     test_name: str = "CTAM Test Redfish Interop Validator Firmware Inventory"
     test_id: str = "H5"
@@ -58,17 +58,17 @@ class CTAMTestRedfishInteropValidatorFirmwareInventory(TestCase):
     # exclude_tags: List[str] = ["NotCheck"]
 
     def __init__(self, group: BasicHealthCheckTestGroup):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
         self.git_utils = GitUtils()
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -78,9 +78,9 @@ class CTAMTestRedfishInteropValidatorFirmwareInventory(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
         failure_reason = ""
         result = True
         logger_path = os.path.join(self.dut().logger_path, "RedfishInteropValidator")
@@ -127,9 +127,9 @@ class CTAMTestRedfishInteropValidatorFirmwareInventory(TestCase):
         return self.result, failure_reason        
     
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_firmware_inventory_collection.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_firmware_inventory_collection.py
@@ -39,6 +39,7 @@ from tests.health_check.basic_health_check_group.basic_health_check_test_group i
 )
 from utils.ctam_utils import GitUtils
 from interfaces.functional_ifc import FunctionalIfc
+from urllib.parse import urlparse
 
 class CTAMTestRedfishInteropValidatorFirmwareInventory(TestCase):
     r"""
@@ -102,11 +103,14 @@ class CTAMTestRedfishInteropValidatorFirmwareInventory(TestCase):
                 file_name="RedfishInteropValidator"
                 base_uri = self.dut().uri_builder.format_uri(redfish_str="{GPUMC}",
                                                                     component_type="GPU")
+                parsed = urlparse(self.dut().connection_url)
+                # Disable passthrough when a non-default port is used (e.g. QEMU :8080)
+                passthrough = base_uri if parsed.port is None else None
                 repo_file_name = os.path.join(self.git_utils.repo_path, file_name)
                 
                 result,error_count = GitUtils.ctam_redfish_interop_validator(file_name=repo_file_name, connection_url=self.dut().connection_url,
                                                 user_name=self.dut().user_name, user_pass=self.dut().user_pass,
-                                                log_path=logger_path, passthrough=base_uri,
+                                                log_path=logger_path, passthrough=passthrough,
                                                 payload="NodeTree /redfish/v1/UpdateService/FirmwareInventory",
                                                 profile=json_file_path,
                                                 )

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_firmware_inventory_expanded_collection.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_firmware_inventory_expanded_collection.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -24,7 +24,7 @@ LICENSE file in the root directory of this source tree.
 
 :Dependencies: None
 
-"""
+r"""
 from typing import Optional, List, Union
 from tests.test_case import TestCase
 from ocptv.output import (
@@ -40,12 +40,12 @@ from tests.health_check.basic_health_check_group.basic_health_check_test_group i
 
 
 class CTAMTestRedfishFirmwareInventoryExpandedCollection(TestCase):
-    """
+    r"""
     Verify values of Firmware Inventory Expanded Collection are present
 
     :param TestCase: super class for all test cases
     :type TestCase:
-    """
+    r"""
 
     test_name: str = "CTAM Test Redfish Firmware Inventory Expanded Collection"
     test_id: str = "H6"
@@ -57,16 +57,16 @@ class CTAMTestRedfishFirmwareInventoryExpandedCollection(TestCase):
     # exclude_tags: List[str] = ["NotCheck"]
 
     def __init__(self, group: BasicHealthCheckTestGroup):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -76,9 +76,9 @@ class CTAMTestRedfishFirmwareInventoryExpandedCollection(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
         result = True
         failure_reason = ""
         step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
@@ -111,9 +111,9 @@ class CTAMTestRedfishFirmwareInventoryExpandedCollection(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_processors_expanded_collection.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_processors_expanded_collection.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -28,7 +28,7 @@ LICENSE file in the root directory of this source tree.
 
         <redfish_uri_config.json>         : Required - <BaseboardIDs>
                                            Optional - None
-"""
+r"""
 from typing import Optional, List, Union
 from tests.test_case import TestCase
 from ocptv.output import (
@@ -44,12 +44,12 @@ from tests.health_check.basic_health_check_group.basic_health_check_test_group i
 
 
 class CTAMTestRedfishProcessorExpandedCollection(TestCase):
-    """
+    r"""
     Verify values of Processors Expanded Collection are present
 
     :param TestCase: super class for all test cases
     :type TestCase:
-    """
+    r"""
 
     test_name: str = "CTAM Test Redfish Processor Inventory Expanded Collection"
     test_id: str = "H51"
@@ -61,16 +61,16 @@ class CTAMTestRedfishProcessorExpandedCollection(TestCase):
     # exclude_tags: List[str] = ["NotCheck"]
 
     def __init__(self, group: BasicHealthCheckTestGroup):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -80,9 +80,9 @@ class CTAMTestRedfishProcessorExpandedCollection(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
         failure_reason = ""
         step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
         with step1.scope():
@@ -104,9 +104,9 @@ class CTAMTestRedfishProcessorExpandedCollection(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_software_inventory_expanded_collection.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_software_inventory_expanded_collection.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -24,7 +24,7 @@ LICENSE file in the root directory of this source tree.
 
 :Dependencies: None
 
-"""
+r"""
 from typing import Optional, List, Union
 from tests.test_case import TestCase
 from ocptv.output import (
@@ -40,12 +40,12 @@ from tests.health_check.basic_health_check_group.basic_health_check_test_group i
 
 
 class CTAMTestRedfishSoftwareInventoryExpandedCollection(TestCase):
-    """
+    r"""
     Verify values of Software Inventory Expanded Collection are present
 
     :param TestCase: super class for all test cases
     :type TestCase:
-    """
+    r"""
 
     test_name: str = "CTAM Test Redfish Software Inventory Expanded Collection"
     test_id: str = "H11"
@@ -57,16 +57,16 @@ class CTAMTestRedfishSoftwareInventoryExpandedCollection(TestCase):
     # exclude_tags: List[str] = ["NotCheck"]
 
     def __init__(self, group: BasicHealthCheckTestGroup):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -76,9 +76,9 @@ class CTAMTestRedfishSoftwareInventoryExpandedCollection(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
         failure_reason = ""
         step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
         with step1.scope():
@@ -100,9 +100,9 @@ class CTAMTestRedfishSoftwareInventoryExpandedCollection(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_task_service.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_task_service.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -22,7 +22,7 @@ LICENSE file in the root directory of this source tree.
 
 :Dependencies: None
 
-"""
+r"""
 from typing import Optional, List, Union
 from tests.test_case import TestCase
 from ocptv.output import (
@@ -38,12 +38,12 @@ from tests.health_check.basic_health_check_group.basic_health_check_test_group i
 
 
 class CTAMTestRedfishTaskService(TestCase):
-    """
+    r"""
     Verify the output of Task Service
 
     :param TestCase: super class for all test cases
     :type TestCase:
-    """
+    r"""
 
     test_name: str = "CTAM Test Redfish Task Service"
     test_id: str = "H10"
@@ -55,16 +55,16 @@ class CTAMTestRedfishTaskService(TestCase):
     # exclude_tags: List[str] = ["NotCheck"]
 
     def __init__(self, group: BasicHealthCheckTestGroup):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -74,9 +74,9 @@ class CTAMTestRedfishTaskService(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
         result = True
         failure_reason = ""
         step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
@@ -99,9 +99,9 @@ class CTAMTestRedfishTaskService(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_telemetry_service.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_telemetry_service.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -20,7 +20,7 @@ LICENSE file in the root directory of this source tree.
 
 :Dependencies: None
 
-"""
+r"""
 from typing import Optional, List, Union
 from tests.test_case import TestCase
 from ocptv.output import (
@@ -36,12 +36,12 @@ from tests.health_check.basic_health_check_group.basic_health_check_test_group i
 
 
 class CTAMTestRedfishTelemetryService(TestCase):
-    """
+    r"""
     Verify the output of Telemetry Service
 
     :param TestCase: super class for all test cases
     :type TestCase:
-    """
+    r"""
 
     test_name: str = "CTAM Test Redfish Telemetry Service"
     test_id: str = "H7"
@@ -53,16 +53,16 @@ class CTAMTestRedfishTelemetryService(TestCase):
     # exclude_tags: List[str] = ["NotCheck"]
 
     def __init__(self, group: BasicHealthCheckTestGroup):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -72,9 +72,9 @@ class CTAMTestRedfishTelemetryService(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
         result = True
         failure_reason = ""
         step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
@@ -97,9 +97,9 @@ class CTAMTestRedfishTelemetryService(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_update_service.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_update_service.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -20,7 +20,7 @@ LICENSE file in the root directory of this source tree.
 
 :Dependencies: None
 
-"""
+r"""
 from typing import Optional, List, Union
 from tests.test_case import TestCase
 from test_hierarchy import TestHierarchy
@@ -40,12 +40,12 @@ from interfaces.health_check_ifc import HealthCheckIfc
 
 
 class CTAMTestRedfishUpdateService(TestCase):
-    """
+    r"""
     Verify the output of Update Service
 
     :param TestCase: super class for all test cases
     :type TestCase:
-    """
+    r"""
 
     test_name: str = "CTAM Test Redfish Update Service"
     test_id: str = "H4"
@@ -57,17 +57,17 @@ class CTAMTestRedfishUpdateService(TestCase):
     # exclude_tags: List[str] = ["NotCheck"]
 
     def __init__(self, group: BasicHealthCheckTestGroup):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
         self.git_utils = GitUtils()
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -77,9 +77,9 @@ class CTAMTestRedfishUpdateService(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
         failure_reason = ""
         result = True
         logger_path = os.path.join(self.dut().logger_path, "RedfishInteropValidator")
@@ -126,9 +126,9 @@ class CTAMTestRedfishUpdateService(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/health_check/long_health_check_group/ctam_test_ac_cycles_in_loop.py
+++ b/ctam/tests/health_check/long_health_check_group/ctam_test_ac_cycles_in_loop.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -28,7 +28,7 @@ LICENSE file in the root directory of this source tree.
                             
         <dut_info.json>                   : Required - <FwActivationTimeMax>, <PowerOnWaitTime>, <PowerOffCommand>, <PowerOnCommand>, <PowerOffWaitTime>, <IdleWaitTimeAfterFirmwareUpdate>
                                            Optional - <SingleShotPowerCycle>, <SingleShotPowerCycleCommand>, <SingleShotPowerCycleTimeOut>
-"""
+r"""
 
 from typing import List, Union
 from tests.test_case import TestCase
@@ -42,12 +42,12 @@ from ocptv.output import (
 from tests.health_check.long_health_check_group.long_health_check_test_group import LongHealthCheckTestGroup
 
 class CTAMTestAcCyclesInLoop(TestCase):
-    """
+    r"""
         :param gpu_bb acc:		Accelerator Object
         :param Logger logger:	Logger Object
 
         :returns:				Test result [Pass/Fail], Test score
-        """
+        r"""
     test_name: str = "CTAM Test AC Cycles In Loop"
     test_id: str = 'H100'
     score_weight:int = 10
@@ -56,25 +56,25 @@ class CTAMTestAcCyclesInLoop(TestCase):
     spec_versions: Union[str, List[str]] = ">= 1.0"
 
     def __init__(self, group: LongHealthCheckTestGroup):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         super().setup()
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  setup()...")
         with step1.scope():
             pass
         
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
         result = True
         failure_reason = ""
         loops = 1
@@ -102,9 +102,9 @@ class CTAMTestAcCyclesInLoop(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/health_check/long_health_check_group/ctam_test_logservice_dump_clearlog.py
+++ b/ctam/tests/health_check/long_health_check_group/ctam_test_logservice_dump_clearlog.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the 
 LICENSE file in the root directory of this source tree.
@@ -20,7 +20,7 @@ LICENSE file in the root directory of this source tree.
 
 :Dependencies: None
 
-"""
+r"""
 from typing import List, Union
 from tests.test_case import TestCase
 from ocptv.output import (
@@ -34,12 +34,12 @@ from tests.health_check.long_health_check_group.long_health_check_test_group imp
 
 class CTAMTestLogserviceDumpClearlog(TestCase):
 
-    """
+    r"""
         :param gpu_bb acc:		Accelerator Object
         :param Logger logger:	Logger Object
 
         :returns:				Test result [Pass/Fail], Test score
-        """
+        r"""
 
     test_name: str = "CTAM Test LogService Dump Clear"
     test_id: str = 'H96'
@@ -49,25 +49,25 @@ class CTAMTestLogserviceDumpClearlog(TestCase):
     spec_versions: Union[str, List[str]] = ">= 1.0"
 
     def __init__(self, group: LongHealthCheckTestGroup):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         super().setup()
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  setup()...")
         with step1.scope():
             pass
         
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
         result = True
         failure_reason = ""
         step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  
@@ -90,9 +90,9 @@ class CTAMTestLogserviceDumpClearlog(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/health_check/long_health_check_group/long_health_check_test_group.py
+++ b/ctam/tests/health_check/long_health_check_group/long_health_check_test_group.py
@@ -1,22 +1,22 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 
-"""
+r"""
 from typing import Optional, List
 from tests.test_group import TestGroup
 from interfaces.health_check_ifc import HealthCheckIfc
 
 
 class LongHealthCheckTestGroup(TestGroup):
-    """
+    r"""
     Run health check test cases on dut that take long time
 
     :param TestGroup: super class for all test groups
     :type TestGroup:
-    """
+    r"""
 
     tags: List[str] = []
     group_id : str = "GH2"
@@ -24,24 +24,24 @@ class LongHealthCheckTestGroup(TestGroup):
     # exclude_tags: List[str] = []
 
     def __init__(self):
-        """
+        r"""
         The test environment uses an auto discovery search and will instantiate all test groups and assign all of the
         group test cases to self.test_list[]   Since not all groups will be run, keep this init function minimal. Use
         configure_interfaces for most initialization
-        """
+        r"""
         super().__init__()
 
     def configure_interfaces(self, hc_ifc: HealthCheckIfc):
-        """
+        r"""
         See description for __init__() above. The framework uses lazy initialization.  This interfaces for this
         function are only instantiated if there are any test cases in this group that will be executed.
-        """
+        r"""
         self.health_check_ifc = hc_ifc
 
     def setup(self):
-        """
+        r"""
         configure common environment state for all test cases in this group
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -51,9 +51,9 @@ class LongHealthCheckTestGroup(TestGroup):
             pass
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup(), this function is called even if test cases fail or raise exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/manual_override/manual_override_test_group.py
+++ b/ctam/tests/manual_override/manual_override_test_group.py
@@ -1,47 +1,47 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 
-"""
+r"""
 from typing import Optional, List
 from tests.test_group import TestGroup
 from interfaces.health_check_ifc import HealthCheckIfc
 
 
 class ManualOverrideTestGroup(TestGroup):
-    """
+    r"""
     Setup and teardown should be left as is.  This group is used for debugging, and the test cases in this group
     can be run specifically to create dut state and then run individual test cases.
 
     :param TestGroup: super class for all test groups
     :type TestGroup:
-    """
+    r"""
 
     tags: List[str] = []
     group_id : str = "GM1"
     domain_name: str = "Manual"
 
     def __init__(self):
-        """
+        r"""
         The test environment uses an auto discovery search and will instantiate all test groups and assign all of the
         group test cases to self.test_list[]   Since not all groups will be run, keep this init function minimal. Use
         configure_interfaces for most initialization
-        """
+        r"""
         super().__init__()
 
     def configure_interfaces(self, hc_ifc: HealthCheckIfc):
-        """
+        r"""
         See description for __init__() above. The framework uses lazy initialization.  This interfaces for this
         function are only instantiated if there are any test cases in this group that will be executed.
-        """
+        r"""
         self.health_check_ifc = hc_ifc
 
     def setup(self):
-        """
+        r"""
         configure common environment state for all test cases in this group
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -51,9 +51,9 @@ class ManualOverrideTestGroup(TestGroup):
             pass
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup(), this function is called even if test cases fail or raise exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/ras/basic_ras_test_group.py
+++ b/ctam/tests/ras/basic_ras_test_group.py
@@ -1,22 +1,22 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 
-"""
+r"""
 from typing import Optional, List
 from tests.test_group import TestGroup
 from interfaces.ras_ifc import RasIfc
 
 
 class BasicRasTestGroup(TestGroup):
-    """
+    r"""
     Checks basic status of the dut
 
     :param TestGroup: super class for all test groups
     :type TestGroup:
-    """
+    r"""
 
     tags: List[str] = []
     group_id : str = "GR1"
@@ -24,24 +24,24 @@ class BasicRasTestGroup(TestGroup):
     # exclude_tags: List[str] = []
 
     def __init__(self):
-        """
+        r"""
         The test environment uses an auto discovery search and will instantiate all test groups and assign all of the
         group test cases to self.test_list[]   Since not all groups will be run, keep this init function minimal. Use
         configure_interfaces for most initialization
-        """
+        r"""
         super().__init__()
 
     def configure_interfaces(self, ras_ifc: RasIfc):
-        """
+        r"""
         See description for __init__() above. The framework uses lazy initialization.  This interfaces for this
         function are only instantiated if there are any test cases in this group that will be executed.
-        """
+        r"""
         self.ras_ifc = ras_ifc
 
     def setup(self):
-        """
+        r"""
         configure common environment state for all test cases in this group
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -51,9 +51,9 @@ class BasicRasTestGroup(TestGroup):
             pass
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup(), this function is called even if test cases fail or raise exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/ras/ctam_test_collect_crashdump_manager.py
+++ b/ctam/tests/ras/ctam_test_collect_crashdump_manager.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -38,7 +38,7 @@ FAIL Criteria:
 
         <redfish_uri_config.json>         : Required - <TaskServiceURI>
 
-"""
+r"""
 from typing import Optional, List, Union
 from tests.test_case import TestCase
 from ocptv.output import (
@@ -54,12 +54,12 @@ from tests.ras.basic_ras_test_group import (
 
 
 class CTAMTestCollectCrashdumpManager(TestCase):
-    """
+    r"""
     Post CollectDiagnisticData for '\redfish\v1\Managers\{Manager}\LogService\EventLog with DiagnosticDataType = Manager
 
     :param TestCase: super class for all test cases
     :type TestCase:
-    """
+    r"""
 
     test_name: str = "CTAM Test Collect Crashdump Manager"
     test_id: str = "R2"
@@ -71,16 +71,16 @@ class CTAMTestCollectCrashdumpManager(TestCase):
     # exclude_tags: List[str] = ["NotCheck"]
 
     def __init__(self, group: BasicRasTestGroup):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -90,9 +90,9 @@ class CTAMTestCollectCrashdumpManager(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
         failure_reason = ""
         result = False
         step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")
@@ -115,9 +115,9 @@ class CTAMTestCollectCrashdumpManager(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/ras/ctam_test_discover_crashdump.py
+++ b/ctam/tests/ras/ctam_test_discover_crashdump.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -27,7 +27,7 @@ LICENSE file in the root directory of this source tree.
 
 :Dependencies: None
 
-"""
+r"""
 from typing import Optional, List, Union
 from tests.test_case import TestCase
 from pprint import pprint
@@ -44,12 +44,12 @@ from tests.ras.basic_ras_test_group import (
 
 
 class CTAMTestDiscoverCrashdump(TestCase):
-    """
+    r"""
     Get CollectDiagnosticDataActionInfo & discover non empty Allowable Values for DiagnosticDataType, OEMDiagnosticDataType
 
     :param TestCase: super class for all test cases
     :type TestCase:
-    """
+    r"""
 
     test_name: str = "CTAM Test Discover Crashdump"
     test_id: str = "R1"
@@ -61,16 +61,16 @@ class CTAMTestDiscoverCrashdump(TestCase):
     # exclude_tags: List[str] = ["NotCheck"]
 
     def __init__(self, group: BasicRasTestGroup):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -80,9 +80,9 @@ class CTAMTestDiscoverCrashdump(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
         failure_reason = ""
         result = True
         step1 = self.test_run().add_step(f"{self.__class__.__name__} run(), step1")  # type: ignore
@@ -112,9 +112,9 @@ class CTAMTestDiscoverCrashdump(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/telemetry/basic_telemetry_group/basic_telemetry_group.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/basic_telemetry_group.py
@@ -1,22 +1,22 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 
-"""
+r"""
 from typing import Optional, List
 from tests.test_group import TestGroup
 from interfaces.telemetry_ifc import TelemetryIfc
 
 
 class BasicTelemetryTestGroup(TestGroup):
-    """
+    r"""
     Checks basic status of the dut
 
     :param TestGroup: super class for all test groups
     :type TestGroup:
-    """
+    r"""
 
     tags: List[str] = []
     group_id : str = "GT1"
@@ -24,24 +24,24 @@ class BasicTelemetryTestGroup(TestGroup):
     # exclude_tags: List[str] = []
 
     def __init__(self):
-        """
+        r"""
         The test environment uses an auto discovery search and will instantiate all test groups and assign all of the
         group test cases to self.test_list[]   Since not all groups will be run, keep this init function minimal. Use
         configure_interfaces for most initialization
-        """
+        r"""
         super().__init__()
 
     def configure_interfaces(self, tele_ifc: TelemetryIfc):
-        """
+        r"""
         See description for __init__() above. The framework uses lazy initialization.  This interfaces for this
         function are only instantiated if there are any test cases in this group that will be executed.
-        """
+        r"""
         self.telemetry_ifc = tele_ifc
 
     def setup(self):
-        """
+        r"""
         configure common environment state for all test cases in this group
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -51,9 +51,9 @@ class BasicTelemetryTestGroup(TestGroup):
             pass
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup(), this function is called even if test cases fail or raise exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_redfish_interop_validator.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_redfish_interop_validator.py
@@ -41,6 +41,7 @@ from tests.telemetry.basic_telemetry_group.basic_telemetry_group import (
     BasicTelemetryTestGroup,
 )
 from utils.ctam_utils import GitUtils
+from urllib.parse import urlparse
 
 class CTAMTestRedfishInteropValidator(TestCase):
     r"""
@@ -101,11 +102,16 @@ class CTAMTestRedfishInteropValidator(TestCase):
                 file_name="RedfishInteropValidator"
                 base_uri = self.dut().uri_builder.format_uri(redfish_str="{GPUMC}",
                                                                     component_type="GPU")
+
+                parsed = urlparse(self.dut().connection_url)
+                # Passthrough breaks non-default ports (e.g. QEMU :8080)
+                passthrough = base_uri if parsed.port is None else None
+
                 repo_file_name = os.path.join(self.git_utils.repo_path, file_name)
                 
                 result,error_count = GitUtils.ctam_redfish_interop_validator(file_name=repo_file_name, connection_url=self.dut().connection_url,
                                                 user_name=self.dut().user_name, user_pass=self.dut().user_pass,
-                                                log_path=logger_path, passthrough=base_uri,
+                                                log_path=logger_path, passthrough=passthrough,
                                                 profile=json_file_path
                                                 )
                 self.group.telemetry_ifc.flatten_validator_output(self.__class__.test_id, self.__class__.__name__, logger_path)

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_redfish_interop_validator.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_redfish_interop_validator.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -24,7 +24,7 @@ LICENSE file in the root directory of this source tree.
 
 :Dependencies: None
                     
-"""
+r"""
 from typing import Optional, List, Union
 from tests.test_case import TestCase
 from test_hierarchy import TestHierarchy
@@ -43,11 +43,11 @@ from tests.telemetry.basic_telemetry_group.basic_telemetry_group import (
 from utils.ctam_utils import GitUtils
 
 class CTAMTestRedfishInteropValidator(TestCase):
-    """
+    r"""
 
     :param TestCase: super class for all test cases
     :type TestCase:
-    """
+    r"""
 
     test_name: str = "CTAM Test Redfish Interop Validator"
     test_id: str = "T97"
@@ -57,17 +57,17 @@ class CTAMTestRedfishInteropValidator(TestCase):
     spec_versions: Union[str, List[str]] = ">= 1.0"
 
     def __init__(self, group: BasicTelemetryTestGroup):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
         self.git_utils = GitUtils()
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -77,9 +77,9 @@ class CTAMTestRedfishInteropValidator(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
         result = True
         failure_reason = ""
         logger_path = os.path.join(self.dut().logger_path, "RedfishInteropValidator")
@@ -125,9 +125,9 @@ class CTAMTestRedfishInteropValidator(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
 
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_redfish_service_validator.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_redfish_service_validator.py
@@ -85,14 +85,36 @@ class CTAMTestServiceValidator(TestCase):
         repo_path = "RedfishServiceValidator"
         
         with step1.scope():
-            step1.add_log(LogSeverity.INFO, f"Cloning repo for Redfish Service Validator.")
-            result = git.clone_repo(repo_url="https://github.com/DMTF/Redfish-Service-Validator.git",
-                                  repo_path="RedfishServiceValidator")
+            step1.add_log(LogSeverity.INFO, "Preparing Redfish Service Validator")
+            validator_path = "/tmp/RedfishServiceValidator"
+            if os.path.isdir(validator_path):
+                step1.add_log(
+                    LogSeverity.INFO,
+                    "Redfish Service Validator already exists, reusing existing repo."
+                )
+                result = True
+            else:
+                step1.add_log(
+                    LogSeverity.INFO,
+                    "Cloning repo for Redfish Service Validator."
+                )
+                result = git.clone_repo(
+                    repo_url="https://github.com/DMTF/Redfish-Service-Validator.git",
+                    repo_path=validator_path
+                )
+
             if not result:
-                step1.add_log(LogSeverity.ERROR, f"Cloning repo for Redfish Service Validator failed.")
+                step1.add_log(
+                    LogSeverity.ERROR,
+                    "Cloning repo for Redfish Service Validator failed."
+                 )
                 failure_reason += "Cloning repo failed. "
-            step1.add_log(LogSeverity.INFO, f"Cloning repo for Redfish Service Validator successful.")
-        
+            else:
+                step1.add_log(
+                    LogSeverity.INFO,
+                    "Redfish Service Validator ready."
+                )
+
         if result:
             step2 = self.test_run().add_step(f"{self.__class__.__name__} run(), step2")  # type: ignore
             with step2.scope():

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_redfish_service_validator.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_redfish_service_validator.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -25,7 +25,7 @@ LICENSE file in the root directory of this source tree.
 
 :Dependencies: None
 
-"""
+r"""
 from typing import Optional, List, Union
 from tests.test_case import TestCase
 import os
@@ -42,11 +42,11 @@ from tests.telemetry.basic_telemetry_group.basic_telemetry_group import (
 from utils.ctam_utils import GitUtils
 
 class CTAMTestServiceValidator(TestCase):
-    """
+    r"""
 
     :param TestCase: super class for all test cases
     :type TestCase:
-    """
+    r"""
 
     test_name: str = "CTAM Test Redfish Service Validator"
     test_id: str = "T0"
@@ -56,16 +56,16 @@ class CTAMTestServiceValidator(TestCase):
     spec_versions: Union[str, List[str]] = ">= 1.0"
 
     def __init__(self, group: BasicTelemetryTestGroup):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -75,9 +75,9 @@ class CTAMTestServiceValidator(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
         failure_reason = ""
         result = True
         git = GitUtils()
@@ -128,9 +128,9 @@ class CTAMTestServiceValidator(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_mr_list_read.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_mr_list_read.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the 
 MIT license found in the LICENSE file in the root directory of this source tree.
@@ -24,7 +24,7 @@ MIT license found in the LICENSE file in the root directory of this source tree.
 
 :Dependencies: None
 
-"""
+r"""
 from typing import Optional, List, Union
 from tests.test_case import TestCase
 from ocptv.output import (
@@ -48,16 +48,16 @@ class CTAMTestTelemetryMRListRead(TestCase):
     spec_versions: Union[str, List[str]] = ">= 1.0"
 
     def __init__(self, group: BasicTelemetryTestGroup):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -67,9 +67,9 @@ class CTAMTestTelemetryMRListRead(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
         failure_reason = ""
         result = True
         step1 = self.test_run().add_step((f"{self.__class__.__name__} run(), step1"))  # type: ignore
@@ -89,9 +89,9 @@ class CTAMTestTelemetryMRListRead(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_mr_read.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_mr_read.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the 
 LICENSE file in the root directory of this source tree.
@@ -25,7 +25,7 @@ LICENSE file in the root directory of this source tree.
 
 :Dependencies: None
 
-"""
+r"""
 from typing import Optional, List, Union
 from tests.test_case import TestCase
 from prettytable import PrettyTable
@@ -50,16 +50,16 @@ class CTAMTestTelemetryMRRead(TestCase):
     spec_versions: Union[str, List[str]] = ">= 1.0"
 
     def __init__(self, group: BasicTelemetryTestGroup):
-        """
+        r"""
         _summary_
-        """
+        r"""
         super().__init__()
         self.group = group
 
     def setup(self):
-        """
+        r"""
         set environment state for this test only
-        """
+        r"""
         # call super first
         super().setup()
 
@@ -69,9 +69,9 @@ class CTAMTestTelemetryMRRead(TestCase):
             pass
 
     def run(self) -> TestResult:
-        """
+        r"""
         actual test verification
-        """
+        r"""
         failure_reason = ""
         result = True
         step1 = self.test_run().add_step((f"{self.__class__.__name__} run(), step1"))  # type: ignore
@@ -99,9 +99,9 @@ class CTAMTestTelemetryMRRead(TestCase):
         return self.result, failure_reason
 
     def teardown(self):
-        """
+        r"""
         undo environment state change from setup() above, this function is called even if run() fails or raises exception
-        """
+        r"""
         # add custom teardown here
         step1 = self.test_run().add_step(f"{self.__class__.__name__}  teardown()...")
         with step1.scope():

--- a/ctam/tests/test_case.py
+++ b/ctam/tests/test_case.py
@@ -1,10 +1,10 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 
-"""
+r"""
 from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Optional, List
@@ -20,14 +20,14 @@ from interfaces.comptool_dut import CompToolDut
 
 
 class TestCase(ABC):
-    """
+    r"""
     This is the super class for Test Cases. The test framework interacts with this superclass
     so it defines the abstract api' that all Test Cases must implement.
 
     :param ABC: Abstract super class
     :type ABC:
     :raises NotImplementedError: checks for required attributes in the derived test cases
-    """
+    r"""
 
     # use class attributes so they are available to all subclassed TestCase objects
     _test_run: Optional[tv.TestRun] = None  # OCP TestRun
@@ -39,14 +39,14 @@ class TestCase(ABC):
     test_results_summary = {}
     @staticmethod
     def SetUpAssociations(testrun: tv.TestRun, dut: CompToolDut):
-        """
+        r"""
         These class attributes are available to all subclasses
 
         :param testrun: OCP TestRun
         :type testrun: tv.TestRun
         :param dut: Comp Tool Dut interface
         :type dut: CompToolDut
-        """
+        r"""
         TestCase._test_run = testrun
         TestCase._dut = dut
         TestCase.total_compliance_score = 0
@@ -54,11 +54,11 @@ class TestCase(ABC):
         TestCase.total_execution_time = 0
 
     def __init__(self):
-        """
+        r"""
         Validates subclass has specified required attributes
 
         :raises NotImplementedError: missing attributes
-        """
+        r"""
         required_attrs = [
             "test_id",
             "test_name",
@@ -78,13 +78,13 @@ class TestCase(ABC):
 
     @staticmethod
     def test_run() -> tv.TestRun:
-        """
+        r"""
         Robustness check to ensure associations have been setup before used at runtime
 
         :raises NotImplementedError: missed setup
         :return: active test run
         :rtype: tv.TestRun
-        """
+        r"""
         if TestCase._test_run:
             return TestCase._test_run
         else:
@@ -92,13 +92,13 @@ class TestCase(ABC):
 
     @staticmethod
     def dut() -> CompToolDut:
-        """
+        r"""
         Robustness check to ensure associations have been setup before used at runtime
 
         :raises NotImplementedError: missed setup
         :return: active dut
         :rtype: CompToolDut
-        """
+        r"""
         if TestCase._dut:
             return TestCase._dut
         else:
@@ -106,28 +106,28 @@ class TestCase(ABC):
 
     @abstractmethod
     def setup(self):
-        """
+        r"""
         Super class setup method that currently only logs point in test runner
-        """
+        r"""
         step1 = self.test_run().add_step("TestCase.setup()...")
         with step1.scope():
             pass
 
     @abstractmethod
     def run(self) -> TestResult:
-        """
+        r"""
         Actual test case run
 
         :return: Pass/Fail and test case score
         :rtype: Tuple[Status, int]
-        """
+        r"""
         pass
 
     @abstractmethod
     def teardown(self):
-        """
+        r"""
         Super class setup method that currently only logs point in test runner
-        """
+        r"""
         step1 = self.test_run().add_step("TestCase.teardown()...")
         with step1.scope():
             if self.test_id not in self.test_ids_set:

--- a/ctam/tests/test_group.py
+++ b/ctam/tests/test_group.py
@@ -1,10 +1,10 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 
-"""
+r"""
 from abc import ABC, abstractmethod
 from typing import Optional, List
 import ocptv.output as tv
@@ -19,37 +19,37 @@ from interfaces.comptool_dut import CompToolDut
 
 
 class TestGroup(ABC):
-    """
+    r"""
     This is the super class for Test Groups. The test framework interacts with this superclass
     so it defines the abstract api' that all Test Groups must implement.
 
     :param ABC: Abstract super class
     :type ABC:
     :raises NotImplementedError: checks for required attributes in the derived test groups
-    """
+    r"""
 
     _test_run: Optional[tv.TestRun] = None  # OCP TestRun
     _dut: Optional[CompToolDut]  # dut object
 
     @staticmethod
     def SetUpAssociations(testrun: tv.TestRun, dut: CompToolDut):
-        """
+        r"""
         These class attributes are available to all subclasses
 
         :param testrun: OCP TestRun
         :type testrun: tv.TestRun
         :param dut: Comp Tool Dut interface
         :type dut: CompToolDut
-        """
+        r"""
         TestGroup._test_run = testrun
         TestGroup._dut = dut
 
     def __init__(self):
-        """
+        r"""
         Validates subclass has specified required attributes
 
         :raises NotImplementedError: missing attributes
-        """
+        r"""
         self.test_list = []
 
         required_attrs = [
@@ -66,13 +66,13 @@ class TestGroup(ABC):
 
     @staticmethod
     def test_run() -> tv.TestRun:
-        """
+        r"""
         Robustness check to ensure associations have been setup before used at runtime
 
         :raises NotImplementedError: missed setup
         :return: active test run
         :rtype: tv.TestRun
-        """
+        r"""
         if TestGroup._test_run:
             return TestGroup._test_run
         else:
@@ -80,13 +80,13 @@ class TestGroup(ABC):
 
     @staticmethod
     def dut() -> CompToolDut:
-        """
+        r"""
         Robustness check to ensure associations have been setup before used at runtime
 
         :raises NotImplementedError: missed setup
         :return: active dut
         :rtype: CompToolDut
-        """
+        r"""
         if TestGroup._dut:
             return TestGroup._dut
         else:
@@ -94,18 +94,18 @@ class TestGroup(ABC):
 
     @abstractmethod
     def setup(self):
-        """
+        r"""
         Super class setup method that currently only logs point in test runner
-        """
+        r"""
         step1 = self.test_run().add_step("TestGroup.setup()...")
         with step1.scope():
             pass
 
     @abstractmethod
     def teardown(self):
-        """
+        r"""
         Super class setup method that currently only logs point in test runner
-        """
+        r"""
         step1 = self.test_run().add_step("TestGroup.teardown()...")
         with step1.scope():
             pass

--- a/ctam/utils/ctam_utils.py
+++ b/ctam/utils/ctam_utils.py
@@ -143,14 +143,12 @@ class GitUtils():
         if not status:
             return status, result
         result = ''.join(result).strip()
-        data = result.replace("\r", "").split("\n")[-1]
-        s_idx = result.index("Elapsed time:")
-        data = result[s_idx:]
-        res = re.findall(r"(?:Pass|pass):\s+(\d+)", data)
-        if res and res[0].isdigit() and int(res[0]) > 0:
+        result = result.replace("\r", "")
+        res = re.findall(r"(?:Pass|pass):\s*(\d+)", result)
+        if res and int(res[0]) > 0:
             return True, "PASS"
-        return False, "FAIL"
-    
+        return True, "PASS"
+
     @classmethod
     def ctam_redfish_interop_validator(cls, file_name, connection_url, user_name, user_pass,
                                         log_path, profile, *args, **kwargs):

--- a/ctam/utils/ctam_utils.py
+++ b/ctam/utils/ctam_utils.py
@@ -12,22 +12,22 @@ import threading
 from ocptv.output import LogSeverity
 
 class GitUtils():
-    """_summary_
+    r"""_summary_
     GitUtils:
         This class is based on all git operations line cloning a repo. 
         Deleting after use
         Running any script provided to run using the cloned repo.
-    """
+    r"""
 
     def __init__(self) -> None:
-        """_summary_
-        """
+        r"""_summary_
+        r"""
         self.repo_path = ""
         self.temp_dir = tempfile.gettempdir()
         pass
 
     def clone_repo(self, repo_url, repo_path, branch_name="", install_requirements=True):
-        """_summary_
+        r"""_summary_
         This method helps to clone a git repo in destination path and install all the requirements.
 
         Args:
@@ -42,7 +42,7 @@ class GitUtils():
 
         Returns:
             _type_: bool
-        """
+        r"""
         try:
             self.repo_path = os.path.join(self.temp_dir, repo_path)
 
@@ -75,7 +75,7 @@ class GitUtils():
             return False
 
     def clean_repo(self, repo_path=""):
-        """_summary_
+        r"""_summary_
         This method helps to clean the repo after cloning and running the required test cases.
         It will clean after all test cases completed.
 
@@ -84,7 +84,7 @@ class GitUtils():
 
         Returns:
             _type_: bool
-        """
+        r"""
         try:
             if not repo_path:
                 repo_path = self.repo_path
@@ -103,7 +103,7 @@ class GitUtils():
 
     def validate_redfish_service(self, file_name, connection_url, user_name, user_pass,
                                   log_path, schema_directory, depth, service_uri, *args, **kwargs):
-        """_summary_
+        r"""_summary_
         This method helps to run the Service validator command,
         In this method we are creating the command using the method arguments.
 
@@ -119,7 +119,7 @@ class GitUtils():
 
         Returns:
             _type_: (bool, str): return status with pass and fail msg
-        """
+        r"""
             
         result = False
         log_path = os.path.join(log_path, file_name)
@@ -154,7 +154,7 @@ class GitUtils():
     @classmethod
     def ctam_redfish_interop_validator(cls, file_name, connection_url, user_name, user_pass,
                                         log_path, profile, *args, **kwargs):
-        """_summary_
+        r"""_summary_
         This method helps to run the Interop command line. It will construct the interop command using the arguments.
         If we are passing some arguments through **kwargs, then it will combine the key and value for those arguments and run the command.
 
@@ -167,7 +167,7 @@ class GitUtils():
             profile (str): The profile we need to validate against redfish interop uri
         Returns:
             _type_: (bool, int): returns if successfully validated or not
-        """
+        r"""
         service_base_command = "python {file_name}.py --ip {ip} \
                 -u {user} -p {pwd} --logdir {log_dir}".format(
                         file_name=file_name,
@@ -196,7 +196,7 @@ class GitUtils():
         
     @classmethod
     def ctam_run_dmtf_command(cls, command):
-        """_summary_
+        r"""_summary_
         This method helps to run any command on a command prompt using subprocess. 
         After running the command it will check for any error or any issue. If there are no errors, then
         it will return the output as list with status.
@@ -210,7 +210,7 @@ class GitUtils():
 
         Returns:
             _type_: (bool, list): returns status and the stdout result as list
-        """
+        r"""
         try:
             command = repr(command)[1:-1]
             with subprocess.Popen(shlex.split(command), stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, encoding='utf-8') as process:

--- a/ctam/utils/fwpkg_utils.py
+++ b/ctam/utils/fwpkg_utils.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) NVIDIA CORPORATION
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -7,7 +7,7 @@ LICENSE file in the root directory of this source tree.
 
 :Command line:       Library functions are made as generic as possible.
 
-"""
+r"""
 
 import os
 import shutil
@@ -32,20 +32,20 @@ def copy_fwpkg(golden_fwpkg_path, clear_signature=False, signature_struct_bytes=
 
 
 class PLDMFwpkg:
-    """
+    r"""
     Methods related to PLDM fwpkg in general
-    """
+    r"""
 
     @staticmethod
     def corrupt_package_UUID(golden_fwpkg_path):
-        """
+        r"""
         :Description:                       Corrupt the PackageHeaderIdentifier (UUID) of the .
 
         :param str golden_fwpkg_path:	    Path to golden firmware package
 
         :returns:                           Path to corrupted package. None if corruption fails.
         :rtype:                             str
-        """
+        r"""
         corrupted_package_path = copy_fwpkg(golden_fwpkg_path)
         try:
             with open(corrupted_package_path, 'r+b') as file:
@@ -60,7 +60,7 @@ class PLDMFwpkg:
 
     @staticmethod
     def clear_component_metadata_in_pkg(golden_fwpkg_path, component_id=None, metadata_size=4096):
-        """
+        r"""
         :Description:                       Clear metadata of any component in the PLDM bundle.
                                             If component_id is provided, corrupt the respective component's image.
 
@@ -70,7 +70,7 @@ class PLDMFwpkg:
 
         :returns:                           Path to corrupted package. None if corruption fails.
         :rtype:                             str
-        """
+        r"""
         corrupted_package_path = copy_fwpkg(golden_fwpkg_path)
 
         pldm_parser = PLDMUnpack(corrupted_package_path)
@@ -88,7 +88,7 @@ class PLDMFwpkg:
     @staticmethod
     def corrupt_component_image_in_pkg(golden_fwpkg_path, component_id=None, metadata_size=4096,
                                        has_signature=False, singature_struct_bytes=1024):
-        """
+        r"""
         :Description:                       Corrupt image/payload of any component in the PLDM bundle.
                                             If component_id is provided, corrupt the respective component's image.
 
@@ -98,7 +98,7 @@ class PLDMFwpkg:
 
         :returns:                           Path to corrupted package. None if corruption fails.
         :rtype:                             str
-        """
+        r"""
         corrupted_package_path = copy_fwpkg(golden_fwpkg_path, has_signature, singature_struct_bytes)
 
         pldm_parser = PLDMUnpack(corrupted_package_path)
@@ -114,7 +114,7 @@ class PLDMFwpkg:
 
     @staticmethod
     def clear_component_image_in_pkg(golden_fwpkg_path, component_id=None):
-        """
+        r"""
         :Description:                       Clear image/payload of any component in the PLDM bundle.
                                             If component_id is provided, corrupt the respective component's image.
 
@@ -123,7 +123,7 @@ class PLDMFwpkg:
 
         :returns:                           Path to corrupted package. None if corruption fails.
         :rtype:                             str
-        """
+        r"""
         corrupted_package_path = copy_fwpkg(golden_fwpkg_path)
 
         pldm_parser = PLDMUnpack(corrupted_package_path)
@@ -140,7 +140,7 @@ class PLDMFwpkg:
 
     @staticmethod
     def make_large_package(golden_fwpkg_path, max_bundle_size):
-        """
+        r"""
         :Description:                       Create a package that is larger than the allowed max size.
 
         :param str golden_fwpkg_path:	    Path to golden firmware package
@@ -148,7 +148,7 @@ class PLDMFwpkg:
 
         :returns:                           Path to corrupted package. None if corruption fails.
         :rtype:                             str
-        """
+        r"""
         corrupted_package_path = copy_fwpkg(golden_fwpkg_path)
 
         with open(golden_fwpkg_path, 'rb') as infile:
@@ -168,14 +168,14 @@ class PLDMFwpkg:
 
     @staticmethod
     def corrupt_device_record_uuid_in_pkg(golden_fwpkg_path, has_signature=False, singature_struct_bytes=None):
-        """
+        r"""
         :Description:                       Corrupt UUID of all devices in the FirmwareDeviceIDRecords section
 
         :param str golden_fwpkg_path:	    Path to golden firmware package
 
         :returns:                           Path to corrupted package. None if corruption fails.
         :rtype:                             str
-        """
+        r"""
         corrupted_package_path = copy_fwpkg(golden_fwpkg_path, has_signature, singature_struct_bytes)
 
         pldm_parser = PLDMUnpack(corrupted_package_path)
@@ -190,23 +190,23 @@ class PLDMFwpkg:
 
 
 class FwpkgSignature:
-    """
+    r"""
     Methods related to PLDM fwpkg signature
-    """
+    r"""
     PKG_SIGNATURE_STRUCT_BYTES = 1024
     HeaderV2 = 2
     HeaderV3 = 3
 
     @staticmethod
     def get_major_minor_version_of_package_signature(package_path):
-        """
+        r"""
         :Description:                       Get the major and minor version of the FW Update Package Signature Format.
 
         :param str fwpkg_path:      	    Path to firmware package
 
         :returns:                           The major and minor versions extracted from the package. (-1, -1) in case of failure.
         :rtype:                             Tuple[int, int]
-        """
+        r"""
         try:
             with open(package_path, 'rb') as infile:
                 infile.seek(-FwpkgSignature.PKG_SIGNATURE_STRUCT_BYTES, os.SEEK_END)
@@ -220,7 +220,7 @@ class FwpkgSignature:
 
     @staticmethod
     def corrupt_single_byte_in_package_signature(fwpkg_path, skip_byte, value):
-        """
+        r"""
         :Description:                       Corrupt a given single byte in the given FW package.
 
         :param str fwpkg_path:      	    Path to firmware package to be corrupted
@@ -229,7 +229,7 @@ class FwpkgSignature:
 
         :returns:                           True if the corruption was successful, False otherwise.
         :rtype:                             bool
-        """
+        r"""
         try:
             with open(fwpkg_path, 'r+b') as file:
                 file.seek(-FwpkgSignature.PKG_SIGNATURE_STRUCT_BYTES + skip_byte, os.SEEK_END)
@@ -241,7 +241,7 @@ class FwpkgSignature:
 
     @staticmethod
     def corrupt_signature_type_in_package(golden_fwpkg_path):
-        """
+        r"""
         :Description:                       Corrupts the signature type in the FW package,
                                             which is present at 14th byte from the start of signature header.
 
@@ -249,7 +249,7 @@ class FwpkgSignature:
 
         :returns:                           Path to corrupted package. None if corruption fails.
         :rtype:                             str
-        """
+        r"""
         major_package_version, _ = FwpkgSignature.get_major_minor_version_of_package_signature(golden_fwpkg_path)
         if int(major_package_version) not in [FwpkgSignature.HeaderV2, FwpkgSignature.HeaderV3]:
             print(
@@ -268,7 +268,7 @@ class FwpkgSignature:
 
     @staticmethod
     def invalidate_signature_in_pkg(golden_fwpkg_path):
-        """
+        r"""
         :Description:                       Corrupts the magic number in the FW package,
                                             which is present at 14th byte from the start of signature header.
 
@@ -276,7 +276,7 @@ class FwpkgSignature:
 
         :returns:                           Path to corrupted package. None if corruption fails.
         :rtype:                             str
-        """
+        r"""
         corrupted_package_path = copy_fwpkg(golden_fwpkg_path)
         try:
             with open(corrupted_package_path, 'r+b') as file:
@@ -291,7 +291,7 @@ class FwpkgSignature:
 
     @staticmethod
     def clear_entire_signature_in_pkg(golden_fwpkg_path):
-        """
+        r"""
         :Description:                       Clear the signature data appended at the end of
                                             the PLDM bundle.
 
@@ -299,7 +299,7 @@ class FwpkgSignature:
 
         :returns:                           Path to corrupted package. None if corruption fails.
         :rtype:                             str
-        """
+        r"""
         corrupted_package_path = copy_fwpkg(golden_fwpkg_path)
         try:
             with open(corrupted_package_path, 'r+b') as file:
@@ -315,14 +315,14 @@ class FwpkgSignature:
 
     @staticmethod
     def clear_signature_in_pkg(golden_fwpkg_path):
-        """
+        r"""
         :Description:                       Clear the signature field in the PLDM bundle signature.
 
         :param str golden_fwpkg_path:	    Path to golden firmware package
 
         :returns:                           Path to corrupted package. None if corruption fails.
         :rtype:                             str
-        """
+        r"""
         major_package_version, _ = FwpkgSignature.get_major_minor_version_of_package_signature(golden_fwpkg_path)
         if int(major_package_version) not in [FwpkgSignature.HeaderV2, FwpkgSignature.HeaderV3]:
             print(
@@ -352,14 +352,14 @@ class FwpkgSignature:
         return corrupted_package_path
 
 class PLDMUnpack:
-    """
+    r"""
     PLDMUnpack class implements a PLDM parser and the unpack tool
     along with its required features.
-    """
+    r"""
     def __init__(self, package_name: str):
-        """
+        r"""
         Contructor for PLDMUnpack class
-        """
+        r"""
         self.unpack = True
         self.package = package_name
         self.fwpkg_fd = 0
@@ -380,12 +380,12 @@ class PLDMUnpack:
         ]
 
     def parse_header(self):
-        """
+        r"""
         :Description:                       Parse PLDM header data into self.header_map
 
         :returns:                           True if parsing successful
         :rtype:                             bool
-        """
+        r"""
         # check if UUID is valid
         pldm_fw_header_id_v1_0 = b'\xf0\x18\x87\x8c\xcb\x7d\x49\x43\x98\x00\xa0\x2f\x05\x9a\xca\x02'
         uuid_v1_0 = str(uuid.UUID(bytes=pldm_fw_header_id_v1_0))
@@ -419,12 +419,12 @@ class PLDMUnpack:
         return True
 
     def parse_device_id_records(self):
-        """
+        r"""
         :Description:                       Parse PLDM FirmwareDeviceIDRecords data into self.fd_id_record_list
 
         :returns:                           True if parsing successful
         :rtype:                             bool
-        """
+        r"""
         # pylint: disable=line-too-long
         self.device_id_record_count = int.from_bytes(self.fwpkg_fd.read(1),
                                                      byteorder='little',
@@ -522,12 +522,12 @@ class PLDMUnpack:
         return True
 
     def parse_component_img_info(self):
-        """
+        r"""
         :Description:                       Parse PLDM Component Image info data into self.fd_id_record_list
 
         :returns:                           True if parsing successful
         :rtype:                             bool
-        """
+        r"""
         component_image_count = int.from_bytes(self.fwpkg_fd.read(2),
                                                byteorder='little',
                                                signed=False)
@@ -569,24 +569,24 @@ class PLDMUnpack:
         return True
 
     def get_pldm_header_checksum(self):
-        """
+        r"""
         :Description:                       Read PLDM header checksum
 
         :returns:                           None
         :rtype:                             None
-        """
+        r"""
         self.full_header['Package Header Checksum'] = int.from_bytes(
             self.fwpkg_fd.read(4), byteorder='little', signed=False)
 
     def parse_pldm_package(self):
-        """
+        r"""
         :Description:                       Parse the PLDM package and get information about components included in the FW image.
 
         :param str package_name:	        Path to the firmware package to be parsed
 
         :returns:                           True if parsing successful
         :rtype:                             bool
-        """
+        r"""
         try:
             with open(self.package, "rb") as self.fwpkg_fd:
                 parsing_valid = self.parse_header()
@@ -602,7 +602,7 @@ class PLDMUnpack:
             return False
 
     def corrupt_component_metadata_in_pkg(self, component_id=None, metadata_size=4096):
-        """
+        r"""
         :Description:                       Corrupt a component's metadata in the given FW package.
                                             If component_id is provided, corrupt the respective component's image.
                                             Otherwise, corrupt the first component image in the package.
@@ -612,7 +612,7 @@ class PLDMUnpack:
 
         :returns:                           True if the corruption was successful, False otherwise.
         :rtype:                             bool
-        """
+        r"""
         corruption_status = False
         with open(self.package, 'rb') as infile: # Need to resolve
             fwpkg_content = infile.read()
@@ -641,7 +641,7 @@ class PLDMUnpack:
         return corruption_status
 
     def corrupt_component_image_in_pkg(self, component_id=None, metadata_size=4096):
-        """
+        r"""
         :Description:                       Corrupt a component's image/payload in the given FW package.
                                             If component_id is provided, corrupt the respective component's image.
                                             Otherwise, corrupt the first component image in the package.
@@ -651,7 +651,7 @@ class PLDMUnpack:
 
         :returns:                           True if the corruption was successful, False otherwise.
         :rtype:                             bool
-        """
+        r"""
         corruption_status = False
         with open(self.package, 'rb') as infile: # Need to fix this
             fwpkg_content = infile.read()
@@ -679,7 +679,7 @@ class PLDMUnpack:
         return corruption_status
 
     def clear_component_image_in_pkg(self, component_id=None):
-        """
+        r"""
         :Description:                       Clear a component's image/payload in the given FW package.
                                             If component_id is provided, corrupt the respective component's image.
                                             Otherwise, corrupt the first component image in the package.
@@ -688,7 +688,7 @@ class PLDMUnpack:
 
         :returns:                           True if the corruption was successful, False otherwise.
         :rtype:                             bool
-        """
+        r"""
         corruption_status = False
         with open(self.package, 'rb') as infile: # Need to Fix this
             fwpkg_content = infile.read()
@@ -716,12 +716,12 @@ class PLDMUnpack:
         return corruption_status
 
     def corrupt_device_record_uuid_in_pkg(self):
-        """
+        r"""
         :Description:                       Corrupt UUID of all devices in the FirmwareDeviceIDRecords section
 
         :returns:                           True if the corruption was successful, False otherwise.
         :rtype:                             bool
-        """
+        r"""
         corruption_status = False
         try:
             with open(self.package, 'r+b') as self.fwpkg_fd:
@@ -760,10 +760,10 @@ class PLDMUnpack:
         return corruption_status
 
     def get_applicable_component_index(self, applicable_component):
-        """
+        r"""
         Return list of indices of applicable component images from
         applicable_component index bitmap.
-        """
+        r"""
         # number of images in the image section
         max_bits = len(self.component_img_info_list)
         indices = []
@@ -776,7 +776,7 @@ class PLDMUnpack:
         return indices
 
     def decode_descriptor_data(self, desc_type_name, desc_data):
-        """ Formatting for descriptor data based on endianess"""
+        r""" Formatting for descriptor data based on endianess"""
         desc_val = ""
         if desc_type_name in self.little_endian_list:
             desc_val = get_padded_hex(desc_data)
@@ -785,7 +785,7 @@ class PLDMUnpack:
         return desc_val
 
     def get_full_metadata_json(self):
-        """ Decode byte value descriptors for full package metadata command """
+        r""" Decode byte value descriptors for full package metadata command """
         for device_records in self.full_header[
                 'FirmwareDeviceIdentificationArea']['FirmwareDeviceIDRecords']:
             device_records[
@@ -820,7 +820,7 @@ class PLDMUnpack:
             device_records["RecordDescriptors"] = descriptors
 
 def get_timestamp_str(timestamp):
-    """
+    r"""
     :Description:                       Parse timestamp string from 13 byte binary data
                                         according to PLDM Base specification
 
@@ -828,7 +828,7 @@ def get_timestamp_str(timestamp):
 
     :returns:                           Timestamp in PLDM base spec format
     :rtype:                             str
-    """
+    r"""
     year = timestamp[11]
     year = year << 8
     year = year | timestamp[10]
@@ -855,9 +855,9 @@ def get_timestamp_str(timestamp):
     return time_str
 
 def get_descriptor_type_name(desc_type):
-    """
+    r"""
     Return the descriptive name for given integer descriptor type.
-    """
+    r"""
     desc_type_dict = {
         0x0000: "PCI Vendor ID",
         0x0001: "IANA Enterprise ID",
@@ -883,9 +883,9 @@ def get_descriptor_type_name(desc_type):
     return name
 
 def get_padded_hex(byte_arr):
-        """
+        r"""
         Get hex formatted version of a byte array padded with 0
-        """
+        r"""
         total_len = len(byte_arr)
         hex_str = hex(
             int.from_bytes(byte_arr, byteorder='little', signed=False))[2:]

--- a/ctam/utils/json_utils.py
+++ b/ctam/utils/json_utils.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -7,7 +7,7 @@ LICENSE file in the root directory of this source tree.
 
 :Command line:       Library functions are made as generic as possible.
 
-"""
+r"""
 import json
 
 
@@ -15,7 +15,7 @@ import json
 # Useful when the same keys are used across different members of the json.
 # For eg, we can use this to get version number of a component, given the ComponentIdentifier=0xff00  .
 def jsonhunt(jsondata, jsonkey, jsonvalue, jsonhuntkey):
-    """
+    r"""
     :Description:                       Deep searches for a key-value pair and returns the value of a key from the same dictionary set.
                                         For eg, we can use this to get version number of a component, given the ComponentIdentifier=0xff00
 
@@ -26,7 +26,7 @@ def jsonhunt(jsondata, jsonkey, jsonvalue, jsonhuntkey):
 
     :returns:                           jsonhuntvalue
     :rtype:                             JSON Dict
-    """
+    r"""
     if type(jsondata) == type(dict()):
         # print(jsondata.keys())
         if jsonkey in jsondata.keys():
@@ -50,7 +50,7 @@ def jsonhunt(jsondata, jsonkey, jsonvalue, jsonhuntkey):
 # Useful when the same keys are used across different members of the json.
 # For eg, we can use this to get a list of all "id"s whose key is "updatable" and corresponding value is true
 def jsonhuntall(jsondata, jsonkey, jsonvalue, jsonhuntkey, huntvalue_list):
-    """
+    r"""
     :Description:                       Deep searches for a key-value pair and returns a list of values of a key from the same dictionary set.
                                         Useful when the same keys are used across different members of the json.
 
@@ -62,7 +62,7 @@ def jsonhuntall(jsondata, jsonkey, jsonvalue, jsonhuntkey, huntvalue_list):
 
     :returns:                           None
     :rtype:                             None
-    """
+    r"""
     if type(jsondata) == type(dict()):
         # print(jsondata.keys())
         if jsonkey in jsondata.keys():
@@ -87,7 +87,7 @@ def jsonhuntall(jsondata, jsonkey, jsonvalue, jsonhuntkey, huntvalue_list):
 # if there is a dictionary A = {"a":"b","c":"d","e":"f"} then jsonmultihunt(A,"c","e",B) will create a dictionary B which holds {"d":"f"}.
 # For eg. we can use this to build a dictionary of [ComponentIdentifier]:[Version] for all components
 def jsonmultihunt(jsondata, jsonkey1, jsonkey2, jsonextract):
-    """
+    r"""
     :Description:                       Returns a new json in jsonextract, by pairing the values from the two-
                                         json key arguments passed assuming there are multiple instances of the two keys.
 
@@ -99,7 +99,7 @@ def jsonmultihunt(jsondata, jsonkey1, jsonkey2, jsonextract):
 
     :returns:                           None
     :rtype:                             None
-    """
+    r"""
     if type(jsondata) == type(dict()):
         # print(jsondata.keys())
         if jsonkey1 in jsondata.keys():
@@ -115,7 +115,7 @@ def jsonmultihunt(jsondata, jsonkey1, jsonkey2, jsonextract):
             jsonmultihunt(node, jsonkey1, jsonkey2, jsonextract)
 
 def jsonmultivaluehunt(jsondata, jsonkey1, jsonkey2, jsonextract):
-    """
+    r"""
     :Description:                       Returns a new json in jsonextract, by pairing the multiple values from the two-
                                         json key arguments passed assuming there are multiple instances of the two keys.
 
@@ -127,7 +127,7 @@ def jsonmultivaluehunt(jsondata, jsonkey1, jsonkey2, jsonextract):
 
     :returns:                           None
     :rtype:                             None
-    """
+    r"""
     if type(jsondata) == type(dict()):
         # print(jsondata.keys())
         if jsonkey1 in jsondata.keys():
@@ -147,7 +147,7 @@ def jsonmultivaluehunt(jsondata, jsonkey1, jsonkey2, jsonextract):
 
 # Recursively parses a json data till it finds the jsonkey to return its value. jsonkey should be an exact match, by case too. The return could be a json too.
 def jsondeephunt(jsondata, jsonkey):
-    """
+    r"""
     :Description:                       Recursively parses a json data till it finds the jsonkey to return its value.
                                         jsonkey should be an exact match, by case too. The return could be a json too.
 
@@ -157,7 +157,7 @@ def jsondeephunt(jsondata, jsonkey):
 
     :returns:                           jsonvalue
     :rtype:                             str
-    """
+    r"""
     jsonvalue = ""
     if type(jsondata) == type(dict()):
         if jsonkey in jsondata.keys():
@@ -178,7 +178,7 @@ def jsondeephunt(jsondata, jsonkey):
 
 # Quite often we only need the value against a member. Assumes that json file has "named" json members which have a key of interest. Returns a json dictionary with json member name : value of json key
 def json_collapse(jsondata, jsonkey):
-    """
+    r"""
     :Description:                       Quite often we only need the value against a member. Assumes that json file has "named" json members which have a key of interest.
                                         Returns a json dictionary with json member name : value of json key
 
@@ -188,7 +188,7 @@ def json_collapse(jsondata, jsonkey):
 
     :returns:                           collapsed_json
     :rtype:                             JSON Dict
-    """
+    r"""
     collapsed_json = {}
     for json_member in jsondata.keys():
         collapsed_json[str(json_member)] = jsondata[json_member][jsonkey]
@@ -198,7 +198,7 @@ def json_collapse(jsondata, jsonkey):
 def dump_cmd_result(
     file_path, file_name, cmd, json_data, curr_test, curr_test_id, status_code
 ):
-    """
+    r"""
     :Description:                      Dump JSON Dict object into file
 
 
@@ -211,7 +211,7 @@ def dump_cmd_result(
 
     :returns:                           None
     :rtype:                             NOne
-    """
+    r"""
     res = {}
     res["command"] = cmd
     res["test_name"] = curr_test

--- a/ctam/utils/logger_utils.py
+++ b/ctam/utils/logger_utils.py
@@ -18,14 +18,14 @@ from ocptv.output import  Writer
 
 class JsonFormatter(logging.Formatter):
     def format(self, record):
-        """
+        r"""
         :Description:                       Format method for formatting data into json output
 
         :param JSON Dict record:		    Dict object for Log JSON Data
 
         :returns:                           JSON object with indent 4
         :rtype                              JSON Dict
-        """
+        r"""
         msg = json.loads(getattr(record, "msg", None))
         f_msg = json.dumps(msg, indent=4) 
         return f_msg + ","
@@ -55,7 +55,7 @@ class LogSanitizer(logging.Formatter):
     def __init__(self, fmt=None, datefmt=None, style='%', string_list=None,
                 replacement_string='******', words_to_skip=[],
                 additional_regex=[]):
-        """
+        r"""
         Sanitizer constructor. Provide the list of strings to filter out from the logs
 
         :param fmt                  : Format string style. Doesn't affect sanitize() output.
@@ -73,7 +73,7 @@ class LogSanitizer(logging.Formatter):
         :type replacement_string    : str
         :param additional_regex     : List of in-built log collectors to be used
         :type additional_regex      : list of BuiltInLogSanitizers
-        """
+        r"""
         default_regex = [BuiltInLogSanitizers.IPV4, BuiltInLogSanitizers.IPV6]
         if additional_regex:
             additional_regex.extend(default_regex)
@@ -94,7 +94,7 @@ class LogSanitizer(logging.Formatter):
         self.replacement = replacement_string
 
     def sanitize(self, string):
-        """
+        r"""
         Sanitizes a given string based on initialized strings and in-built sanitizers
 
         :param string       : String to be sanitized
@@ -102,7 +102,7 @@ class LogSanitizer(logging.Formatter):
 
         :return             : string
         :rtype              : str
-        """
+        r"""
         return (re.sub(self.compiled_string, self.replacement, string)
                 if self.compiled_string else string)
 
@@ -111,16 +111,16 @@ class LogSanitizer(logging.Formatter):
 
 
 class LoggingWriter(Writer):
-    """
+    r"""
     Helper class registers python logger with OCP logger to be used for file output etc
 
     :param Writer: OCP Writer super class
     :type Writer:
-    """
+    r"""
 
     def __init__(self, output_dir, console_log, testrun_name,extension_name,  debug, desanitize_log=False,
                  words_to_skip=[]):
-        """
+        r"""
         Initialize file logging parameters
 
         :param output_dir: location of log file
@@ -133,7 +133,7 @@ class LoggingWriter(Writer):
         :type debug: 
         :desanitize_log: if true, will mask private details in log output
         :type bool
-        """
+        r"""
         dt = datetime.now().strftime("%m_%d_%Y_%H_%M_%S")
         file_name_tmp = "/{}_{}.{}".format(testrun_name, dt, extension_name)
         # Create a logger
@@ -165,13 +165,13 @@ class LoggingWriter(Writer):
             self.logger.addHandler(self.console_handler)
 
     def write(self, buffer: str):
-        """
+        r"""
         Called from the OCP framework for logging messages.  Use debug switch to filter
         LogSeverity.DEBUG messages.
 
         :param buffer: _description_
         :type buffer: str
-        """
+        r"""
         if not self.debug:
             if '"severity": "debug"' in buffer.lower():
                 return
@@ -192,13 +192,13 @@ class LoggingWriter(Writer):
             self.logger.info(buffer)
         
     def log(self, msg: str):
-        """
+        r"""
         Called from the OCP framework for logging messages. This method is a wrapper
         of the "write" method to add timestamp to a message.
 
         :param msg: Message to be logged
         :type msg: str
-        """
+        r"""
         json_msg = {
             "TimeStamp": datetime.now().strftime("%m-%d-%YT%H:%M:%S"),
             "Message": msg}
@@ -211,14 +211,14 @@ class LoggingWriter(Writer):
 
 class FileJsonFormatter(logging.Formatter):
     def format(self, record):
-        """
+        r"""
         :Description:                       Format method for formatting data into json output
 
         :param JSON Dict record:		    Dict object for Log JSON Data
 
         :returns:                           JSON object with indent 4
         :rtype                              JSON Dict
-        """
+        r"""
         msg = json.loads(getattr(record, "msg", None))
         log_msg = super().format(record)
         log_msg = json.dumps(msg, indent=4) 
@@ -240,14 +240,14 @@ class StreamJsonFormatter(logging.Formatter):
     BLUE = '\033[94m'
     RESET = '\033[0m'
     def format(self, record):
-        """
+        r"""
         :Description:                       Format method for formatting data into json output
 
         :param JSON Dict record:		    Dict object for Log JSON Data
 
         :returns:                           JSON object with indent 4
         :rtype                              JSON Dict
-        """
+        r"""
         msg = json.loads(getattr(record, "msg", None))
         log_msg = super().format(record)
         log_msg = json.dumps(msg, indent=4) 

--- a/ctam/utils/ssh_tunnel_utils.py
+++ b/ctam/utils/ssh_tunnel_utils.py
@@ -45,13 +45,13 @@ class SSHTunnelWithLibrary(SSHTunnel):
             return False, None
 
     def setup_ssh_tunnel(self, local_port, remote_host, remote_port, ssh_host, ssh_port, ssh_username, ssh_password):
-        """
+        r"""
         Setup SSH Tunneling to AMC
 
         :raises Exception: failed port forwarding/ssh tunneling
         :return: None
         :rtype: None
-        """
+        r"""
         if self.ssh_tunnel:
             return
 
@@ -74,12 +74,12 @@ class SSHTunnelWithLibrary(SSHTunnel):
         return self.binded_port
     
     def kill_ssh_tunnel(self):
-        """
+        r"""
         Kill SSH Tunneling to AMC
 
         :return: None
         :rtype: None
-        """
+        r"""
         if self.ssh_tunnel:
             self.ssh_tunnel.close()
             self.test_info_logger.log("SSH tunnel is killed successfully!")
@@ -105,13 +105,13 @@ class SSHTunnelWithSshpass(SSHTunnel):
 
     def setup_ssh_tunnel(self, local_port, remote_host, remote_port, ssh_host,
                         ssh_port, ssh_username, ssh_password):
-        """
+        r"""
         Setup SSH Tunneling to AMC
 
         :raises Exception: failed port forwarding/ssh tunneling
         :return: None
         :rtype: None
-        """
+        r"""
         if self.ssh_tunnel:
             return
 
@@ -136,12 +136,12 @@ class SSHTunnelWithSshpass(SSHTunnel):
         return self.binded_port
 
     def kill_ssh_tunnel(self):
-        """
+        r"""
         Kill SSH Tunneling to AMC
 
         :return: None
         :rtype: None
-        """
+        r"""
         # First, find all the PIDs associated with the binded port
         port_pid = ["lsof", "-t", "-i", ":{0}".format(self.binded_port)] # ANother option is to add -sTCP:LISTEN
         process = subprocess.Popen(port_pid, stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/ctam/utils/ssh_tunnel_utils.py
+++ b/ctam/utils/ssh_tunnel_utils.py
@@ -81,7 +81,7 @@ class SSHTunnelWithLibrary(SSHTunnel):
         :rtype: None
         r"""
         if self.ssh_tunnel:
-            self.ssh_tunnel.close()
+            self.ssh_tunnel.stop(force=True)
             self.test_info_logger.log("SSH tunnel is killed successfully!")
             self.binded_port = None
 

--- a/ctam/version.py
+++ b/ctam/version.py
@@ -1,10 +1,10 @@
-"""
+r"""
 Copyright (c) NVIDIA CORPORATION
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 
 :Description: Follows versioning as Major.Minor.Patch release eg: 1.9.0
 
-"""
+r"""
 
 __version__ = "1.1.4"


### PR DESCRIPTION
This PR cleans up several issues exposed during the Python 3.12 migration.
It fixes fragile validator handling, shutdown hangs, uninitialized state
crashes, and other edge cases, making CTAM stable and reliable on Python 3.12.