### PR TITLE
ctam: Python 3.12 enablement and QEMU execution fixes

### DIFF
--- a/ctam/test_runner.py
+++ b/ctam/test_runner.py
@@ -42,8 +42,11 @@ from interfaces.comptool_dut import CompToolDut
 from utils.logger_utils import LoggingWriter, LogSanitizer, BuiltInLogSanitizers
 
 from version import __version__
-COUNTER = 0   
+COUNTER = 0
 
+class _NullActiveRun:
+    def add_log(self, *args, **kwargs):
+        pass
 
 class TestRunner:
     """
@@ -131,7 +134,9 @@ class TestRunner:
         self.redfish_response_messages = {}
         self.default_config_path = default_config_path
         self.show_spec_bindings = False
-        self.measurements = {}  
+        self.measurements = {}
+        self.writer = None
+        self.active_run = None
     
         if self.default_config_path:
             self._show_spec_bindings()
@@ -385,6 +390,11 @@ class TestRunner:
         :return: status_code, exit_string
         :rtype: int, str 
         """
+        exit_string = ""  # always defined
+        self._executed_any_test = False
+        if self.active_run is None:
+            self.active_run = _NullActiveRun()
+
         try:
             status_code = 0
             self.create_json_configuration()
@@ -559,12 +569,26 @@ class TestRunner:
                 "FailureReason": exception_details
                 }
             self.score_logger.write(json.dumps(msg))
-            status_code, exit_string =  1, f"Test failed due to execption: {repr(e)}"
+            status_code, exit_string =  1, f"Test failed due to execption: {repr(e)}" 
         finally:
             if self.comp_tool_dut:
                 self.comp_tool_dut.clean_up()
-            
-            self.post_proces_logs(self.writer.log_file)
+                
+            if self.writer:
+                self.post_proces_logs(self.writer.log_file)
+            if not self._executed_any_test:
+                log_msg = (
+                    "No runnable CTAM tests were executed for this "
+                    "platform; result is NA."
+                )
+                exit_string = "No applicable tests"
+                if self.active_run:
+                    self.active_run.add_log(
+                        severity=LogSeverity.INFO,
+                        message=log_msg
+                    )
+                else:
+                    print(f"INFO: {log_msg}")
             return status_code, exit_string
         
     def consolidate_run(self):
@@ -794,6 +818,7 @@ class TestRunner:
                         # Inject measurements into all test cases
                         test_instance.measurements = self.measurements
                         test_result, failure_reason = test_instance.run()
+                        self._executed_any_test = True
                         if (
                             test_result == TestResult.FAIL
                         ):  # if any test fails, the group fails
@@ -1474,6 +1499,9 @@ class TestRunner:
         :return: status_code, exit_string
         :rtype: int, str 
         """
+        status_code = -1
+        exit_string = ""
+
         try:
             self._start()
             status_code, exit_string = 0, "System discovery is done"

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_activation_time.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_activation_time.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) NVIDIA CORPORATION
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_activation_with_failed_component.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_activation_with_failed_component.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) NVIDIA CORPORATION
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_in_loop.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_in_loop.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 Copyright (c) NVIDIA CORPORATION
 This source code is licensed under the MIT license found in the

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_ping_pong.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_ping_pong.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_rollback.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_rollback.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_staging_time.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_staging_time.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) NVIDIA CORPORATION
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_staging_with_failed_component.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_staging_with_failed_component.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) NVIDIA CORPORATION
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_with_older_version.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_full_device_update_with_older_version.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_corrupt_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_corrupt_image_update.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_empty_metadata_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_empty_metadata_image_update.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) NVIDIA CORPORATION
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_full_device_update_staging_interruption_with_ac_reset.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_full_device_update_staging_interruption_with_ac_reset.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) NVIDIA CORPORATION
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_device_uuid_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_device_uuid_image_update.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) NVIDIA CORPORATION
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_package_uuid_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_package_uuid_image_update.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) NVIDIA CORPORATION
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_signed_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_invalid_signed_image_update.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_large_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_large_image_update.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_single_device_update_with_illegal_targets.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_single_device_update_with_illegal_targets.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_single_fw_update_staging_interruption_with_ac_reset.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_single_fw_update_staging_interruption_with_ac_reset.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_unsigned_bundle_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_unsigned_bundle_update.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) NVIDIA CORPORATION
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_unsigned_component_image_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_negative_unsigned_component_image_update.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.

--- a/ctam/tests/fw_update/fw_update_group_N/ctam_test_single_device_update_ping_pong.py
+++ b/ctam/tests/fw_update/fw_update_group_N/ctam_test_single_device_update_ping_pong.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.

--- a/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_full_device_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_full_device_update.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.

--- a/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_install_same_image_two_times.py
+++ b/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_install_same_image_two_times.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.

--- a/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_single_device_update.py
+++ b/ctam/tests/fw_update/fw_update_group_N_1/ctam_test_single_device_update.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_logservice_dump_uri_list_read.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_logservice_dump_uri_list_read.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_logservice_uri_list_read.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_logservice_uri_list_read.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_event_service.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_event_service.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_event_service_create_subscription.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_event_service_create_subscription.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_event_service_delete_subscription.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_event_service_delete_subscription.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_event_service_list_subscription.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_event_service_list_subscription.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_firmware_inventory_expanded_collection.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_firmware_inventory_expanded_collection.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_processors_expanded_collection.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_processors_expanded_collection.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_software_inventory_expanded_collection.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_software_inventory_expanded_collection.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_task_service.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_task_service.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_telemetry_service.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_telemetry_service.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.

--- a/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_update_service.py
+++ b/ctam/tests/health_check/basic_health_check_group/ctam_test_redfish_update_service.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.

--- a/ctam/tests/health_check/long_health_check_group/ctam_test_ac_cycles_in_loop.py
+++ b/ctam/tests/health_check/long_health_check_group/ctam_test_ac_cycles_in_loop.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.

--- a/ctam/tests/health_check/long_health_check_group/ctam_test_logservice_dump_clearlog.py
+++ b/ctam/tests/health_check/long_health_check_group/ctam_test_logservice_dump_clearlog.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the 
 LICENSE file in the root directory of this source tree.

--- a/ctam/tests/ras/ctam_test_collect_crashdump_manager.py
+++ b/ctam/tests/ras/ctam_test_collect_crashdump_manager.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -54,7 +54,7 @@ from tests.ras.basic_ras_test_group import (
 
 
 class CTAMTestCollectCrashdumpManager(TestCase):
-    """
+    r"""
     Post CollectDiagnisticData for '\redfish\v1\Managers\{Manager}\LogService\EventLog with DiagnosticDataType = Manager
 
     :param TestCase: super class for all test cases

--- a/ctam/tests/ras/ctam_test_discover_crashdump.py
+++ b/ctam/tests/ras/ctam_test_discover_crashdump.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_redfish_interop_validator.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_redfish_interop_validator.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_redfish_service_validator.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_redfish_service_validator.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_mr_list_read.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_mr_list_read.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the 
 MIT license found in the LICENSE file in the root directory of this source tree.

--- a/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_mr_read.py
+++ b/ctam/tests/telemetry/basic_telemetry_group/ctam_test_telemetry_mr_read.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Copyright (c) Microsoft Corporation
 This source code is licensed under the MIT license found in the 
 LICENSE file in the root directory of this source tree.

--- a/ctam/utils/ssh_tunnel_utils.py
+++ b/ctam/utils/ssh_tunnel_utils.py
@@ -81,7 +81,7 @@ class SSHTunnelWithLibrary(SSHTunnel):
         :rtype: None
         """
         if self.ssh_tunnel:
-            self.ssh_tunnel.close()
+            self.ssh_tunnel.stop(force=True)
             self.test_info_logger.log("SSH tunnel is killed successfully!")
             self.binded_port = None
 


### PR DESCRIPTION

This enables Python 3.12 compatibility and fixes issues impacting **QEMU-based CTAM execution and Interop validation**.

## 🔧 Key Changes

### Python 3.12 Migration
- Converted affected docstrings to raw strings to eliminate `SyntaxWarning`
- Verified clean build with `python3.12 -Wall`
- No functional/runtime changes

### QEMU / CTAM Stability
- Fixed CTAM hang during SSH tunnel cleanup
- Use `stop(force=True)` for reliable teardown
- Ensures clean exit after test execution

### Test Runner Robustness
- Fixed crashes for no-test scenarios (invalid test IDs)
- Proper initialization of `writer` and `active_run`
- Introduced safe handling via `NullActiveRun`

## Impact

- Enables stable **CTAM execution on Python 3.12**
- Fixes **QEMU-based Redfish validation workflows**
- Improves overall **runtime stability**
- No impact to standard deployments
